### PR TITLE
ci: add Trivy & Semgrep security code scanning

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,57 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Runs Semgrep with the open-source rule packs (no Semgrep.dev account/token
+# required) and uploads the SARIF report to the GitHub code scanning tab.
+# See https://semgrep.dev/docs
+
+name: Semgrep
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+  schedule:
+    - cron: '33 16 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    # Semgrep's rule packs are public; no token is needed. Skip on Dependabot
+    # PRs whose token is read-only and cannot upload SARIF.
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mark workspace as safe for git (container runs as root)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # OSS rule packs: Go, generic security audit, secrets and Dockerfile.
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --sarif --output=semgrep.sarif \
+            --config=p/golang \
+            --config=p/security-audit \
+            --config=p/secrets \
+            --config=p/dockerfile
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+        if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: trivy
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+  schedule:
+    - cron: '35 1 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t localbuild/waf:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'localbuild/waf:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Objectif

Ajoute deux pipelines de **code scanning** gratuites (résultats SARIF → onglet Security), choisies pour combler les trous **non** couverts par l'existant (CodeQL + Dependabot + golangci-lint), sans doublon.

| Workflow | Couvre |
|---|---|
| **trivy.yml** | Scan de l'**image Docker** : couches de base + dépendances du binaire Go + secrets (CRITICAL/HIGH) |
| **semgrep.yml** | SAST via packs OSS (`p/golang`, `p/security-audit`, `p/secrets`, `p/dockerfile`) |

## Adaptations vs les templates GitHub

- **Semgrep** : mode **OSS sans token** (le template exige un `SEMGREP_APP_TOKEN` payant qu'on n'a pas). Tourne dans le conteneur `semgrep/semgrep`, scanne avec les packs publics.
- **Trivy** : tag d'image local réel + sortie **SARIF native** au lieu du template `contrib/sarif.tpl` (déprécié/fragile).

## Écartés (redondants pour ce projet)

OSV-Scanner (≈ Dependabot), Anchore Grype (≈ Trivy), Anchore Syft SBOM (≈ dependency graph GitHub), Bearer (≈ CodeQL/Semgrep), Scorecard (hygiène, surtout informatif).

## ⚠️ Stacking

Trivy **construit l'image Docker**, ce qui nécessite le fix Dockerfile **Go 1.26** de #3 — l'image ne build pas sur `main` actuel (`golang:1.22` vs `go 1.24`). Cette PR est donc empilée sur #3 ; une fois #3 mergée, le diff se réduit aux 2 fichiers de workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
