### PR TITLE
fix: resolve Semgrep security findings (JA3 MD5, cookie flags, nginx headers)

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -8,12 +8,15 @@ server {
     # Health probe target for compose dependency ordering.
     location = /healthz {
         access_log off;
-        add_header Content-Type text/plain;
+        # default_type sets the response Content-Type for `return`; using
+        # add_header here would overwrite any server-level headers (semgrep
+        # header-redefinition).
+        default_type text/plain;
         return 200 "origin-ok\n";
     }
 
     location / {
-        add_header Content-Type text/html;
+        default_type text/html;
         return 200 "<!doctype html><html><body><h1>Origin behind GaetanDev WAF</h1><p>If you can read this, the WAF proxied your request.</p></body></html>";
     }
 }

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -8,9 +8,8 @@ server {
     # Health probe target for compose dependency ordering.
     location = /healthz {
         access_log off;
-        # default_type sets the response Content-Type for `return`; using
-        # add_header here would overwrite any server-level headers (semgrep
-        # header-redefinition).
+        # default_type is the correct directive to set the Content-Type for a
+        # `return` response, and avoids the header-redefinition footgun.
         default_type text/plain;
         return 200 "origin-ok\n";
     }

--- a/internal/middleware/challenge/cookie.go
+++ b/internal/middleware/challenge/cookie.go
@@ -69,6 +69,10 @@ func (i CookieIssuer) Issue(ip string, domain string, fpHash string, score int, 
 
 	value, err := i.signPayload(payload)
 	if err != nil {
+		// Cookie vide renvoyé uniquement sur le chemin d'erreur (jamais émis au
+		// client). Le cookie réellement délivré ci-dessous active Secure,
+		// HttpOnly et SameSite. Faux positif de l'analyse OSS (pas de dataflow).
+		// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure, go.lang.security.audit.net.cookie-missing-httponly.cookie-missing-httponly
 		return http.Cookie{}, err
 	}
 

--- a/internal/tlsfp/ja3.go
+++ b/internal/tlsfp/ja3.go
@@ -26,7 +26,15 @@ func JA3String(version uint16, ciphers []uint16, extensions []uint16, curves []u
 }
 
 // JA3Hash retourne le MD5 hexadécimal d'une chaîne JA3 (le hash JA3 standard).
+//
+// MD5 est imposé par la spécification JA3 : le hash est un identifiant de
+// fingerprint (bucketing / corrélation), pas une signature de sécurité, et
+// doit rester du MD5 pour rester interopérable avec les feeds de threat
+// intelligence qui publient des hashes JA3 en MD5. La résistance aux
+// collisions n'est pas un objectif ici, et l'entrée n'est pas un secret.
+// Remplacer MD5 par SHA-256 casserait toute comparaison avec ja3_blacklist.
 func JA3Hash(ja3 string) string {
+	// nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
 	sum := md5.Sum([]byte(ja3))
 	return hex.EncodeToString(sum[:])
 }

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -196,6 +196,7 @@ modification silencieuse, décisions tracées).
 | 2026-06-09 | `crypto...use-of-md5` | `internal/tlsfp/ja3.go` | Supprimé (`nosemgrep`) — faux positif | MD5 imposé par la spec JA3 ; identifiant de fingerprint (FR-11), pas une signature. SHA-256 casserait l'interop avec les feeds JA3 et `ja3_blacklist`. |
 | 2026-06-09 | `net...cookie-missing-secure` | `internal/middleware/challenge/cookie.go` | Supprimé (`nosemgrep`) — faux positif | Match sur le `http.Cookie{}` vide du chemin d'erreur (jamais émis). Le cookie délivré active déjà `Secure: true`. |
 | 2026-06-09 | `net...cookie-missing-httponly` | `internal/middleware/challenge/cookie.go` | Supprimé (`nosemgrep`) — faux positif | Idem : le cookie délivré active déjà `HttpOnly: true` (+ `SameSite=Lax`). L'OSS ne fait pas de dataflow. |
+| 2026-06-09 | `nginx...header-redefinition` (x2) | `deploy/nginx/default.conf` | Corrigé | Remplacé `add_header Content-Type` (qui écrase les en-têtes du bloc server) par `default_type`, directive nginx idiomatique pour `return`. Origine de test du stack compose. |
 
 ## Quality Gates Checklist
 

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -185,6 +185,16 @@ last-reviewed: 2026-06-03
 | 2026-06-08 | Slice 9.10 | `go vet ./...` | pass | No vet findings |
 | 2026-06-08 | Slice 9.10 | `go build ./...` | pass | Maintenance middleware wired between slowloris and security headers |
 
+## Security Scan Triage (Semgrep OSS)
+
+Décisions sur les findings remontés par le workflow Semgrep en code scanning.
+Chaque suppression (`nosemgrep`) est explicite et justifiée (SDD : pas de
+modification silencieuse, décisions tracées).
+
+| Date | Finding (rule id) | Fichier | Décision | Justification |
+|---|---|---|---|---|
+| 2026-06-09 | `crypto...use-of-md5` | `internal/tlsfp/ja3.go` | Supprimé (`nosemgrep`) — faux positif | MD5 imposé par la spec JA3 ; identifiant de fingerprint (FR-11), pas une signature. SHA-256 casserait l'interop avec les feeds JA3 et `ja3_blacklist`. |
+
 ## Quality Gates Checklist
 
 ### G1 — Spec Lint

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -194,6 +194,8 @@ modification silencieuse, décisions tracées).
 | Date | Finding (rule id) | Fichier | Décision | Justification |
 |---|---|---|---|---|
 | 2026-06-09 | `crypto...use-of-md5` | `internal/tlsfp/ja3.go` | Supprimé (`nosemgrep`) — faux positif | MD5 imposé par la spec JA3 ; identifiant de fingerprint (FR-11), pas une signature. SHA-256 casserait l'interop avec les feeds JA3 et `ja3_blacklist`. |
+| 2026-06-09 | `net...cookie-missing-secure` | `internal/middleware/challenge/cookie.go` | Supprimé (`nosemgrep`) — faux positif | Match sur le `http.Cookie{}` vide du chemin d'erreur (jamais émis). Le cookie délivré active déjà `Secure: true`. |
+| 2026-06-09 | `net...cookie-missing-httponly` | `internal/middleware/challenge/cookie.go` | Supprimé (`nosemgrep`) — faux positif | Idem : le cookie délivré active déjà `HttpOnly: true` (+ `SameSite=Lax`). L'OSS ne fait pas de dataflow. |
 
 ## Quality Gates Checklist
 


### PR DESCRIPTION
## Objectif

Traite les 5 findings remontés par le workflow **Semgrep** (code scanning) sur `main`, un commit par correction, décisions tracées dans `specs/validation.md` (SDD — pas de suppression silencieuse).

## Findings & décisions

| # | Finding | Fichier | Décision |
|---|---|---|---|
| 1 | `use-of-md5` | `internal/tlsfp/ja3.go` | **Suppression justifiée** — MD5 est imposé par la spec JA3 (identifiant de fingerprint FR-11, pas une signature) ; SHA-256 casserait l'interop avec les feeds JA3 / `ja3_blacklist`. |
| 2 | `cookie-missing-secure` | `internal/middleware/challenge/cookie.go` | **Faux positif** — match sur le `http.Cookie{}` vide du chemin d'erreur ; le cookie délivré active déjà `Secure: true`. |
| 3 | `cookie-missing-httponly` | `internal/middleware/challenge/cookie.go` | **Faux positif** — idem, `HttpOnly: true` + `SameSite=Lax` déjà présents. |
| 4-5 | `header-redefinition` (x2) | `deploy/nginx/default.conf` | **Corrigé** — `add_header Content-Type` (écrase les en-têtes server) remplacé par `default_type`, directive nginx idiomatique pour `return`. |

## Détail

- **#1 / #2 / #3** sont des faux positifs de Semgrep OSS (pas d'analyse de dataflow) : annotés avec un `nosemgrep` ciblé + commentaire de justification. Aucun changement de comportement.
- **#4 / #5** sont une vraie amélioration : `default_type` est la directive correcte pour fixer le Content-Type d'une réponse `return`, et supprime l'`add_header` à risque. Comportement (Content-Type envoyé) inchangé. Concerne l'origine de test du stack compose.

## Validation

`go build ./...`, `go vet ./...`, `go test ./...` — tous PASS (Go 1.26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
