### PR TITLE
fix: deliver under-attack transition alerts immediately, bypassing co…

### DIFF
--- a/cmd/waf/main.go
+++ b/cmd/waf/main.go
@@ -291,7 +291,10 @@ func run() error {
 			if active {
 				trigger = "under_attack_start"
 			}
-			notifier.Notify(alert.Event{Trigger: trigger, Domain: scope, Action: waflogger.ActionChallenge})
+			// Immediate: une transition est un événement discret (déjà débouncé par
+			// l'hystérésis du contrôleur) ; elle ne doit pas être avalée par le
+			// cooldown de dédup (sinon une réactivation rapprochée n'alerte pas).
+			notifier.Notify(alert.Event{Trigger: trigger, Domain: scope, Immediate: true})
 		})
 	}
 

--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -32,6 +32,10 @@ type Event struct {
 	RequestID  string
 	Country    string
 	TrustScore int
+	// Immediate contourne la déduplication par cooldown. À réserver aux événements
+	// de transition d'état discrets (entrée/sortie de mode), déjà débouncés en
+	// amont — sinon une transition rapprochée d'une précédente serait avalée.
+	Immediate bool
 }
 
 // Alert est le payload d'alerte enrichi (cf. schemas/alert.schema.json).
@@ -110,7 +114,7 @@ func (n *Notifier) worker() {
 
 // Notify construit et dispatche une alerte enrichie à partir d'un événement WAF.
 func (n *Notifier) Notify(ev Event) {
-	n.Dispatch(Alert{
+	alert := Alert{
 		Timestamp:  n.now().UTC().Format(time.RFC3339),
 		Trigger:    ev.Trigger,
 		Severity:   severityFor(ev.Trigger),
@@ -125,7 +129,13 @@ func (n *Notifier) Notify(ev Event) {
 		RequestID:  ev.RequestID,
 		Country:    ev.Country,
 		TrustScore: ev.TrustScore,
-	})
+	}
+	if ev.Immediate {
+		// Transition d'état : toujours livrée, sans passer par le cooldown.
+		n.enqueue(alert)
+		return
+	}
+	n.Dispatch(alert)
 }
 
 // Dispatch enfile une alerte si le cooldown (par trigger+domaine) est écoulé.
@@ -134,6 +144,11 @@ func (n *Notifier) Dispatch(alert Alert) {
 	if !n.allow(alert) {
 		return
 	}
+	n.enqueue(alert)
+}
+
+// enqueue dépose l'alerte dans la file sans bloquer (jetée si la file est pleine).
+func (n *Notifier) enqueue(alert Alert) {
 	select {
 	case n.queue <- alert:
 	default:

--- a/internal/alert/alert_test.go
+++ b/internal/alert/alert_test.go
@@ -99,6 +99,29 @@ func TestCooldownDeduplicates(t *testing.T) {
 	}
 }
 
+// Une transition de mode (Immediate) doit toujours être livrée, même si une
+// transition identique a eu lieu dans le cooldown : sinon une réactivation
+// rapprochée du mode sous attaque (FR-39) passerait silencieuse.
+func TestImmediateBypassesCooldown(t *testing.T) {
+	var count int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&count, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	n := NewNotifier([]Sink{{Type: SinkGeneric, URL: server.URL}}, time.Hour, 0, server.Client())
+	defer n.Close()
+	for i := 0; i < 3; i++ {
+		n.Notify(Event{Trigger: "under_attack_start", Domain: "status.gaetandev.fr", Immediate: true})
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if c := atomic.LoadInt32(&count); c != 3 {
+		t.Fatalf("delivered %d times, want 3 (les transitions Immediate ignorent le cooldown)", c)
+	}
+}
+
 func TestRetryOnFailureThenSuccess(t *testing.T) {
 	var attempts int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -24,6 +24,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `waf_under_attack_challenges_total{domain}` ; alerte FR-29 à l'entrée/sortie du
   mode. Activé par défaut (`enabled: true`). Implémenté Slice 12.1. Voir `ADR-018`,
   `requirements-detection.md` FR-39, `features/anti-ddos.feature`.
+  - Les alertes de transition (`under_attack_start`/`_end`) sont envoyées en mode
+    **`Immediate`** : elles contournent la déduplication par cooldown du Notifier.
+    Sans cela, une **réactivation rapprochée** du mode (attaque en plusieurs vagues
+    séparées d'un creux) dans la fenêtre de cooldown (ex. 5 min) n'était pas alertée.
+    La cadence reste bornée par l'hystérésis du contrôleur (sortie sous
+    `exit_pressure` soutenu `cooldown`).
 
 ### Changed
 

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -212,6 +212,7 @@ last-reviewed: 2026-06-03
 | 2026-06-19 | Slice 12.1 FR-39 under-attack | `go test -race ./internal/middleware/antiddos/... ./internal/middleware/challenge/...` | pass | No data races (per-domain LRU + hysteresis state are mutex-guarded; transition observer invoked outside the lock) |
 | 2026-06-19 | Slice 12.1 FR-39 under-attack | `go test -cover` (touched pkgs) | pass | antiddos 87.3%, challenge 87.1%, config 79.4%, metrics 85.2%, logger 71.0%, alert 82.9% (≥80% on the new business logic) |
 | 2026-06-19 | Slice 12.1 FR-39 under-attack | JSON schema validity (`jq empty`) | pass | config.schema.json + security-event.schema.json valid ; config.example.yaml conforms to schema (jsonschema) |
+| 2026-06-19 | Slice 12.1 FR-39 alert delivery | `go test ./...` | pass | Fix : alertes de transition envoyées en `Immediate` (bypass cooldown). Diagnostic prod (waf-out-10) : attaque en 2 vagues séparées d'un creux >30s → mode activé/levé/réactivé, mais le 2ᵉ `under_attack_start` était avalé par le cooldown 5m du Notifier (même clé trigger+domaine). Test : 3 events Immediate identiques → 3 livrés ; le cooldown dédup normal reste actif pour les autres triggers |
 
 ### Slice 12.1 — Notes & couverture du périmètre (FR-39)
 


### PR DESCRIPTION
…oldown (FR-39)

Diagnostic sur logs prod (waf-out-10) : l'attaque est arrivée en deux vagues séparées par un creux >30s (trafic retombé à normal). Le contrôleur a donc fait start (vague 1) -> end (creux) -> start (vague 2), correctement. Mais le 2e `under_attack_start` n'a pas alerté : le Notifier déduplique par (trigger|domaine) sur un cooldown (5 min en prod), si bien qu'une réactivation rapprochée du mode était avalée.

Une transition d'état est un événement discret, déjà débouncé par l'hystérésis du contrôleur (sortie seulement sous exit_pressure soutenu cooldown). Elle ne doit pas être soumise au cooldown de dédup, conçu pour les alertes répétitives (blocks).

- alert.Event gagne un champ `Immediate` ; Notify l'enfile sans passer par allow() (cooldown). Dispatch/Notify refactorés autour d'un enqueue() commun.
- main.go : les transitions under_attack_start/_end sont émises en Immediate ; l'Action CHALLENGE trompeuse (affichée même sur le "levé") est retirée.
- Test : 3 events Immediate identiques -> 3 livrés ; la dédup par cooldown reste active pour les triggers normaux (TestCooldownDeduplicates inchangé).

Le battement true/false du champ under_attack dans le log est un artefact bénin (ordre d'écriture != ordre des timestamps + requêtes PASS static/whitelist qui court-circuitent le compteur), pas un flap du contrôleur.

## Résumé

<!-- 2-3 bullet points sur ce que fait cette PR et pourquoi. -->

- 
- 

## Références

<!-- Issues fermées, specs modifiées, ADRs créés. -->

- Closes #
- Spec : `specs/...`

---

## Checklist SDD — 7 gates

> Cochez chaque gate avant de demander une review. Une PR sans checklist complète ne sera pas mergée.

### Spécification
- [ ] **G0 — Spec** : toute nouvelle fonctionnalité a une spec `approved` dans `specs/` ; aucun code avant spec
- [ ] **G0 — Pas de breaking change silencieux** : si breaking change → version MAJOR + ADR dans `specs/decisions/`

### Qualité technique
- [ ] **G1 — Spec lint** : `spectral lint` passe sans erreur
- [ ] **G2 — Type check** : `go build ./...` + `go vet ./...` sans erreur
- [ ] **G3 — Conformance API** : réponses HTTP conformes à l'OpenAPI (status codes, schémas, headers)
- [ ] **G4 — Tests** : `go test ./...` passe ; couverture ≥ 80 % sur la logique métier ajoutée
- [ ] **G5 — Sécurité** : pas de nouveau `nosemgrep` / `nolint` sans commentaire justificatif ; pas de secret en clair

### Release
- [ ] **G6 — Performance** : pas de régression observable sur les benchmarks existants
- [ ] **G7 — Review humaine** : au moins un reviewer a relu le diff complet

---

## Plan de test

<!-- Comment vérifier manuellement que ça fonctionne ? -->

- [ ] 
- [ ] 

## Captures / logs (si pertinent)

<!-- Collage de logs JSON, sortie de `go test -v`, trace Prometheus, etc. -->
