### PR TITLE
ci: upgrade GitHub Actions to Node 24 — clear deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint (golangci-lint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -31,15 +31,15 @@ jobs:
     name: Test (race + coverage)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
       - name: go test
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -48,8 +48,8 @@ jobs:
     name: Build (static linux binary)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -63,9 +63,9 @@ jobs:
     name: Spec Lint (spectral)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: spectral lint
         run: npx --yes @stoplight/spectral-cli@6 lint specs/api/admin.openapi.yaml --ruleset .spectral.yaml

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,7 +35,7 @@ jobs:
     # PRs whose token is read-only and cannot upload SARIF.
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Mark workspace as safe for git (container runs as root)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -51,7 +51,7 @@ jobs:
             --config=p/dockerfile
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build an image from Dockerfile
         run: |
@@ -42,6 +42,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Contexte

Tous les runs CI affichaient des avertissements **Node.js 20 deprecated** sur chaque job, et une alerte de dépréciation pour `codeql-action/upload-sarif@v3` (fin de vie décembre 2026). Les actions avaient toutes reçu de nouvelles versions majeures ciblant Node 24.

## Modifications

| Fichier | Action | Avant | Après |
|---|---|---|---|
| `ci.yml` | `actions/checkout` | `v4` | **`v7`** |
| `ci.yml` | `actions/setup-go` | `v5` | **`v6`** |
| `ci.yml` | `actions/upload-artifact` | `v4` | **`v7`** |
| `ci.yml` | `actions/setup-node` + node-version | `v4` / `"20"` | **`v6`** / **`"24"`** |
| `trivy.yml` | `actions/checkout` | `v4` | **`v7`** |
| `trivy.yml` | `codeql-action/upload-sarif` | `v3` | **`v4`** |
| `semgrep.yml` | `actions/checkout` | `v4` | **`v7`** |
| `semgrep.yml` | `codeql-action/upload-sarif` | `v3` | **`v4`** |

## Warnings supprimés

- `Node.js 20 is deprecated … being forced to run on Node.js 24` — sur tous les jobs
- `CodeQL Action v3 will be deprecated in December 2026` — trivy + semgrep

🤖 Generated with [Claude Code](https://claude.com/claude-code)