### PR TITLE
fix(security): resolve code-scanning alert 32 — openpgp false positive + Go 1.26.5

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,6 +40,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Faux positifs documentés (voir commentaires dans .trivyignore).
+          trivyignores: '.trivyignore'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Faux positifs Trivy documentés.
+#
+# GO-2026-5932 — golang.org/x/crypto/openpgp « unsafe by design, unmaintained ».
+# Advisory au niveau PACKAGE sans version corrigée (le package est abandonné,
+# un bump ne peut jamais fermer l'alerte). Trivy raisonne au niveau MODULE :
+# il voit golang.org/x/crypto dans les métadonnées du binaire et colle toutes
+# les advisories du module. Or le seul package importé de ce module est
+# golang.org/x/crypto/acme/autocert (internal/acme/acme.go) ; openpgp n'est
+# jamais importé, donc jamais compilé dans le binaire (liaison Go par package).
+# Vérifié par govulncheck (analyse au niveau symbole) : « your code doesn't
+# appear to call these vulnerabilities ». À réévaluer si un import openpgp
+# apparaît un jour.
+GO-2026-5932

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/gaetandev/waf
 
 go 1.26.0
 
+// GO-2026-5856 (fuite ECH dans crypto/tls, atteignable : le WAF termine le
+// TLS) est corrigé dans la stdlib de go1.26.5 — forcer ce toolchain minimum.
+toolchain go1.26.5
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.20.5

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -8,6 +8,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Security
 
+- Toolchain Go forcé à **`go1.26.5`** (directive `toolchain` dans `go.mod`) :
+  corrige GO-2026-5856 (fuite de confidentialité Encrypted Client Hello dans
+  `crypto/tls`, stdlib), **atteignable** dans le WAF (terminaison TLS,
+  handshakes entrants/sortants) d'après l'analyse au niveau symbole de
+  `govulncheck`.
+- Alerte code-scanning n°32 (GO-2026-5932, `golang.org/x/crypto/openpgp`
+  « unsafe by design ») classée **faux positif** : advisory au niveau package
+  sans version corrigée, alors que le seul package importé du module est
+  `acme/autocert` — `openpgp` n'est jamais compilé dans le binaire. Confirmé
+  par `govulncheck`. Ajout d'un `.trivyignore` documenté, câblé dans le
+  workflow Trivy (`trivyignores`).
 - Montée de version des dépendances `golang.org/x` pour corriger 21 alertes de
   code-scanning (vulnérabilités connues) :
   - `golang.org/x/crypto` `v0.45.0` → `v0.52.0` (13 CVE, dont HIGH


### PR DESCRIPTION
## Résumé

- Ferme l'[alerte code-scanning n°32](https://github.com/GaetanOff/WAF-GaetanDev/security/code-scanning/32) (GO-2026-5932, `golang.org/x/crypto/openpgp` « unsafe by design ») : **faux positif au niveau module**. Le seul package importé de `x/crypto` est `acme/autocert` ([acme.go:12](internal/acme/acme.go)) ; `openpgp` n'est jamais compilé dans le binaire. L'advisory n'a **pas de version corrigée** (package abandonné), aucun bump ne peut donc la fermer → `.trivyignore` documenté, câblé dans le workflow Trivy (`trivyignores`).
- En passant, `govulncheck` (analyse au niveau symbole) a révélé une vulnérabilité stdlib **réellement atteignable** : GO-2026-5856 (fuite Encrypted Client Hello dans `crypto/tls`) — critique pour un WAF qui termine le TLS. Corrigée en forçant `toolchain go1.26.5` dans `go.mod` (s'applique en local, CI et build Docker).
- Après changement : `govulncheck` → **« No vulnerabilities found »** (0 atteignable).

## Références

- Closes https://github.com/GaetanOff/WAF-GaetanDev/security/code-scanning/32
- Spec : `specs/changelog.md` (section Security)

---

## Checklist SDD — 7 gates

### Spécification
- [x] **G0 — Spec** : pas de nouvelle fonctionnalité (remédiation sécurité/outillage) ; changelog mis à jour
- [x] **G0 — Pas de breaking change silencieux** : aucun changement de contrat

### Qualité technique
- [x] **G1 — Spec lint** : specs API inchangées
- [x] **G2 — Type check** : `go build ./...` + `go vet ./...` sans erreur (toolchain go1.26.5)
- [x] **G3 — Conformance API** : aucun endpoint modifié
- [x] **G4 — Tests** : `go test ./... -count=1` → 39 paquets, 0 FAIL
- [x] **G5 — Sécurité** : l'entrée `.trivyignore` est justifiée par un commentaire détaillé (advisory package-level sans fix, package jamais importé, confirmé par govulncheck) ; pas de secret en clair

### Release
- [x] **G6 — Performance** : aucun code applicatif modifié
- [ ] **G7 — Review humaine** : en attente de review

---

## Plan de test

- [x] `govulncheck ./...` avant : GO-2026-5856 atteignable (5 traces via crypto/tls) + GO-2026-5932 non appelé
- [x] `govulncheck ./...` après : « No vulnerabilities found » — seule reste la vuln module non appelée (openpgp, ignorée et documentée)
- [ ] Après merge : vérifier que le run Trivy sur main ne remonte plus l'alerte 32

## Captures / logs (si pertinent)

```
$ govulncheck ./...
No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)