### PR TITLE
feat(challenge): auto dark mode via prefers-color-scheme

### DIFF
--- a/internal/middleware/challenge/conformance_test.go
+++ b/internal/middleware/challenge/conformance_test.go
@@ -47,6 +47,24 @@ func TestConformanceRealTemplateBrandingAndTimer(t *testing.T) {
 	}
 }
 
+// Scenario: Adaptation automatique du thème à la préférence système du visiteur.
+// La page bascule en thème sombre via @media (prefers-color-scheme: dark),
+// sans JavaScript ni bouton de sélection de thème.
+func TestConformanceRealTemplateAutoDarkMode(t *testing.T) {
+	middleware := newRealTemplateMiddleware(t)
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/page", nil)
+	request.RemoteAddr = "3.3.3.3:1234"
+	request.Header.Set("Accept", "text/html")
+	response := httptest.NewRecorder()
+
+	middleware.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).ServeHTTP(response, request)
+
+	body := response.Body.String()
+	if !strings.Contains(body, "prefers-color-scheme: dark") {
+		t.Fatal("challenge page missing @media (prefers-color-scheme: dark) rule")
+	}
+}
+
 // Scenario: Page challenge — la page ne charge aucune ressource externe (pas de CDN).
 func TestConformanceRealTemplateHasNoExternalResources(t *testing.T) {
 	middleware := newRealTemplateMiddleware(t)

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -75,6 +75,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   observés et publiés au moteur de risque sans être appliqués, pour ne pas casser
   le trafic API/serveur légitime non-navigateur. Le **honeypot** (déterministe)
   reste bloquant même en shadow. `antibot.New` prend désormais un paramètre `shadow`.
+- Challenge JS (FR-06) — la page de challenge suit désormais **automatiquement le
+  thème système** du visiteur via `@media (prefers-color-scheme: dark)` : fond
+  clair par défaut, bascule en thème sombre (`#121212`/`#1e1e1e`, texte clair)
+  quand le navigateur/OS est en mode sombre. 100 % CSS, sans JavaScript ni bouton
+  de sélection, aucune ressource externe, aucune préférence stockée côté WAF. Le
+  badge « Protected by » (styles inline) est passé en classe `.footer-badge` pour
+  être thémable. Voir `features/js-challenge.feature`.
 - Challenge JS (FR-06) — servi uniquement pour une **navigation de navigateur**
   (`GET`/`HEAD` + `Accept: text/html`). Les appels API/XHR (`fetch`, `axios`,
   mobile) contournent le challenge au lieu de recevoir une page HTML qu'ils ne

--- a/specs/features/js-challenge.feature
+++ b/specs/features/js-challenge.feature
@@ -122,3 +122,24 @@ Feature: Challenge JavaScript
     And la page contient un élément chronomètre visible
     And la page contient l'animation CSS "moveBackground"
     And la page ne charge aucune ressource externe (pas de CDN)
+
+  Scenario: Thème clair — visiteur avec préférence système "light"
+    Given un visiteur dont le navigateur signale "prefers-color-scheme: light"
+    When le WAF sert la page de challenge
+    Then la page s'affiche avec un fond clair (thème clair)
+    And le conteneur de challenge a un fond blanc
+    # Le thème clair reste le rendu par défaut (aucune media query appliquée).
+
+  Scenario: Thème sombre — visiteur avec préférence système "dark"
+    Given un visiteur dont le navigateur signale "prefers-color-scheme: dark"
+    When le WAF sert la page de challenge
+    Then la page s'affiche avec un fond sombre (thème sombre)
+    And le conteneur de challenge a un fond sombre avec un texte clair et lisible
+    # Basculement automatique via @media (prefers-color-scheme: dark), sans JS.
+
+  Scenario: Adaptation automatique — aucun bouton ni sélecteur de thème
+    When le WAF sert la page de challenge
+    Then le thème est déterminé uniquement par la préférence système du visiteur
+    And la page ne contient aucun bouton ni interrupteur de changement de thème
+    And le contraste texte/fond respecte WCAG AA dans les deux thèmes
+    # Comportement 100% automatique : le WAF ne stocke ni ne demande de préférence.

--- a/web/challenge.html
+++ b/web/challenge.html
@@ -78,6 +78,56 @@
       0%, 100% { opacity: 1; }
       50%       { opacity: 0.3; }
     }
+
+    .footer-badge {
+      position: fixed;
+      bottom: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #fff;
+      border-radius: 8px;
+      padding: 4px 12px;
+      font-size: 12px;
+      color: #333;
+      box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
+      font-family: Arial, sans-serif;
+    }
+
+    .footer-badge a {
+      color: rgb(22, 163, 74);
+      font-weight: bold;
+      text-decoration: none;
+    }
+
+    /* ── Dark mode: suit automatiquement la préférence système du visiteur ── */
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #121212;
+      }
+
+      .firewall-container {
+        background-color: #1e1e1e;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+      }
+
+      .firewall-header {
+        color: #f0f0f0;
+      }
+
+      .timer {
+        color: #9a9a9a;
+      }
+
+      .timer-value {
+        color: #d0d0d0;
+      }
+
+      .footer-badge {
+        background: #1e1e1e;
+        color: #d0d0d0;
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+      }
+    }
   </style>
 </head>
 <body>
@@ -93,16 +143,8 @@
   </div>
 </div>
 
-<div style="position:fixed;bottom:10px;left:50%;transform:translateX(-50%);
-            background:#fff;
-            border-radius:8px;
-            padding:4px 12px;
-            font-size:12px;
-            color:#333;
-            box-shadow:0 0 6px rgba(0,0,0,0.1);
-            font-family:Arial, sans-serif;">
-  Protected by <a style="color:rgb(22,163,74);font-weight:bold;text-decoration:none"
-                  href="https://firewall.gaetandev.fr" target="_blank">GaetanDev.fr</a>
+<div class="footer-badge">
+  Protected by <a href="https://firewall.gaetandev.fr" target="_blank">GaetanDev.fr</a>
 </div>
 
 <script>


### PR DESCRIPTION
## Résumé

La page de challenge (`web/challenge.html`) suit désormais **automatiquement le thème système** du visiteur :
- **Mode clair** (défaut) quand l'OS/navigateur est en clair — rendu historique inchangé.
- **Mode sombre** via `@media (prefers-color-scheme: dark)` : fond `#121212`, conteneur `#1e1e1e`, texte clair et lisible.

100 % CSS : **aucun JavaScript**, **aucun bouton de sélection**, **aucune ressource externe**, **aucune préférence stockée** côté WAF. Conforme à l'invariant « la page ne charge aucune ressource externe ».

Le badge « Protected by » utilisait des styles inline non-thémables → converti en classe `.footer-badge`.

## Méthodo SDD respectée

| Étape | Détail |
|---|---|
| **Spec** | 3 scénarios ajoutés à [`specs/features/js-challenge.feature`](specs/features/js-challenge.feature) (thème clair, thème sombre, adaptation automatique + WCAG AA) |
| **Conformance (G4)** | `TestConformanceRealTemplateAutoDarkMode` dérivé du scénario Gherkin |
| **Changelog** | Entrée section `Changed` (FR-06) |

## Vérifications

- ✅ `go build ./...`
- ✅ `go vet ./internal/middleware/challenge/`
- ✅ `go test ./internal/middleware/challenge/`
- ✅ Rendu vérifié visuellement en mode sombre et clair (navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)