### PR TITLE
fix(antiddos): stop pressure throttle from killing legitimate visitors (FR-05/FR-08 v2.1.0)

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -50,12 +50,17 @@ rate_limit:
 # Protection Anti-DDoS globale
 antiddos:
   enabled: true
-  global_requests_per_second: 50000  # Baseline globale pour calculer la pression adaptative
+  # Baseline de la pression adaptative : à CALIBRER sur le trafic réel du site
+  # (pic légitime observé). Les niveaux se déclenchent à baseline × multiplicateur,
+  # PAS à des valeurs absolues — avec une baseline de 150, critical arrive dès
+  # 600 req/s. Sous pression, le refill du rate limit des visiteurs non TRUSTED
+  # est réduit (burst conservé) et le mode under_attack peut s'enclencher.
+  global_requests_per_second: 50000
   global_window: "1s"                # Fenêtre glissante du compteur global
   pressure_levels:
-    elevated_multiplier: 1           # >= 50k req/s -> pression elevated
-    high_multiplier: 2               # >= 100k req/s -> pression high
-    critical_multiplier: 4           # >= 200k req/s -> pression critical
+    elevated_multiplier: 1           # elevated dès baseline × 1 (ici 50 000 req/s)
+    high_multiplier: 2               # high dès baseline × 2 (ici 100 000 req/s)
+    critical_multiplier: 4           # critical dès baseline × 4 (ici 200 000 req/s)
   retry_after_seconds: 5             # Retry-After pour les limites explicites par IP, pas pour un 503 global
   # Mode "sous attaque" (FR-39) : sous pression avérée, force le challenge JS des
   # requêtes sans clearance (cookie/bot vérifié/whitelist/sticky trust) pour

--- a/internal/middleware/antiddos/middleware.go
+++ b/internal/middleware/antiddos/middleware.go
@@ -126,6 +126,13 @@ func (m Middleware) Handler(next http.Handler) http.Handler {
 
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
 		next.ServeHTTP(recorder, r)
+		if isPressureThrottle(recorder) {
+			// 429 imputable au seul throttle de pression (FR-08) : neutre pour le
+			// breaker — pas une violation (le WAF ouvrirait le circuit à cause des
+			// 429 qu'il a lui-même provoqués), pas un succès non plus (pas de
+			// reset de la série de violations en cours).
+			return
+		}
 		if isViolation(recorder) {
 			m.breaker.RecordViolation(ip)
 			return
@@ -177,6 +184,15 @@ func (r *statusRecorder) WriteHeader(statusCode int) {
 
 func (r *statusRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
+}
+
+// reasonPressureThrottle est posé par le middleware ratelimit sur les 429
+// imputables au seul resserrement de pression globale (FR-08).
+const reasonPressureThrottle = "rate_limit_pressure"
+
+func isPressureThrottle(recorder *statusRecorder) bool {
+	return recorder.statusCode == http.StatusTooManyRequests &&
+		recorder.Header().Get("X-WAF-Reason") == reasonPressureThrottle
 }
 
 func isViolation(recorder *statusRecorder) bool {

--- a/internal/middleware/antiddos/middleware_test.go
+++ b/internal/middleware/antiddos/middleware_test.go
@@ -180,6 +180,51 @@ func TestMiddlewareAllowsKnownVisitorWhenGlobalRateExceeded(t *testing.T) {
 	}
 }
 
+func TestPressureThrottle429DoesNotFeedBreaker(t *testing.T) {
+	store := memory.New(100)
+	defer store.Close()
+	middleware := New(NewCircuitBreaker(store, DefaultViolationThreshold, DefaultOpenDuration), nil, DefaultRetryAfterSeconds)
+	// Simule le middleware ratelimit refusant sous throttle de pression (FR-08).
+	handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-WAF-Action", "RATE_LIMIT")
+		w.Header().Set("X-WAF-Reason", reasonPressureThrottle)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+
+	// Bien au-delà du seuil de violations : le circuit ne doit jamais s'ouvrir.
+	for i := 0; i < DefaultViolationThreshold*3; i++ {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, requestFrom("1.2.3.4:1234"))
+		if response.Code != http.StatusTooManyRequests {
+			t.Fatalf("request %d: status = %d, want 429 (never CIRCUIT_BREAK)", i, response.Code)
+		}
+	}
+}
+
+func TestPressureThrottle429DoesNotResetViolationStreak(t *testing.T) {
+	store := memory.New(100)
+	defer store.Close()
+	breaker := NewCircuitBreaker(store, DefaultViolationThreshold, DefaultOpenDuration)
+	middleware := New(breaker, nil, DefaultRetryAfterSeconds)
+	handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-WAF-Action", "RATE_LIMIT")
+		w.Header().Set("X-WAF-Reason", reasonPressureThrottle)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+
+	for range DefaultViolationThreshold - 1 {
+		breaker.RecordViolation("1.2.3.4")
+	}
+
+	// Un 429 de pression est neutre : il ne remet pas la série à zéro.
+	handler.ServeHTTP(httptest.NewRecorder(), requestFrom("1.2.3.4:1234"))
+
+	breaker.RecordViolation("1.2.3.4")
+	if !breaker.IsOpen("1.2.3.4") {
+		t.Fatal("expected circuit to open: pressure 429 must not reset the violation streak")
+	}
+}
+
 func requestFrom(remoteAddr string) *http.Request {
 	request := httptest.NewRequest(http.MethodGet, "http://example.test/page", nil)
 	request.RemoteAddr = remoteAddr

--- a/internal/middleware/ratelimit/middleware.go
+++ b/internal/middleware/ratelimit/middleware.go
@@ -20,6 +20,13 @@ const (
 	pressureElevated = "elevated"
 	pressureHigh     = "high"
 	pressureCritical = "critical"
+
+	reasonRateLimitExceeded = "rate_limit_exceeded"
+	// ReasonPressureThrottle identifie un 429 imputable au seul resserrement de
+	// pression globale (FR-08) : la requête aurait été admise au débit nominal.
+	// Ces refus sont neutres — ni pénalité de score, ni violation de
+	// circuit-breaker (consommé par le middleware anti-DDoS).
+	ReasonPressureThrottle = "rate_limit_pressure"
 )
 
 type Middleware struct {
@@ -51,24 +58,39 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		ip := cloudflare.RealIP(r)
 		ipHash := trust.HashIP(ip)
 
-		// FR-08 v2 : sous pression globale anti-DDoS, le débit autorisé des
-		// visiteurs non dignes de confiance est resserré (mitigation réversible,
-		// THROTTLE). Les visiteurs TRUSTED (challenge réussi, navigation stable)
-		// conservent leur débit nominal. La pression normale n'a aucun effet.
-		effectiveRate, effectiveCapacity := m.rate, m.capacity
+		// FR-08 v2.1 : sous pression globale anti-DDoS, seul le DÉBIT DE REFILL
+		// des visiteurs non dignes de confiance est resserré — la capacité de
+		// burst reste nominale, pour qu'un chargement de page unique (rafale de
+		// sous-requêtes) passe toujours : c'est le débit soutenu qui distingue
+		// un bot, pas le burst initial. Les visiteurs TRUSTED (challenge réussi,
+		// navigation stable) conservent leur débit nominal.
+		effectiveRate := m.rate
+		pressured := false
 		if factor := m.pressureFactor(r, ip); factor < 1 {
 			effectiveRate *= factor
-			effectiveCapacity *= factor
+			pressured = true
 		}
 
-		bucket := m.loadBucket(ipHash, effectiveRate, effectiveCapacity, now)
+		existing, hasExisting := m.store.GetBucket(ipHash)
+		bucket := m.loadBucket(existing, hasExisting, effectiveRate, m.capacity, now)
 		allowed, retryAfter := bucket.TryConsume(now)
 		snapshot := bucket.Snapshot(now, defaultBucketTTL, ipHash)
 		snapshot.ExpiresAt = time.Now().Add(defaultBucketTTL)
 		m.store.SetBucket(ipHash, toStorageBucket(snapshot))
 
 		if !allowed {
-			visitor := m.scores.Apply(ip, r.Host, trust.DeltaRateLimit)
+			if pressured && m.nominalWouldAllow(existing, hasExisting, now) {
+				// 429 imputable au seul throttle de pression : neutre (FR-08).
+				// Pas de pénalité de score ni de violation de circuit-breaker,
+				// sinon le WAF punit des humains pour les 429 qu'il a lui-même
+				// provoqués (boucle de rétroaction auto-infligée).
+				w.Header().Set("Retry-After", strconv.Itoa(maxInt(1, int(retryAfter.Seconds()))))
+				w.Header().Set("X-WAF-Action", "RATE_LIMIT")
+				w.Header().Set("X-WAF-Reason", ReasonPressureThrottle)
+				http.Error(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
+			visitor := m.scores.PenalizeRateLimit(ip, r.Host)
 			if m.scores.State(visitor.Score) == trust.StateBlocked {
 				w.Header().Set("X-WAF-Action", "BLOCK")
 				w.Header().Set("X-WAF-Reason", "score_below_block_threshold")
@@ -77,7 +99,7 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 			}
 			w.Header().Set("Retry-After", strconv.Itoa(maxInt(1, int(retryAfter.Seconds()))))
 			w.Header().Set("X-WAF-Action", "RATE_LIMIT")
-			w.Header().Set("X-WAF-Reason", "rate_limit_exceeded")
+			w.Header().Set("X-WAF-Reason", reasonRateLimitExceeded)
 			http.Error(w, "too many requests", http.StatusTooManyRequests)
 			return
 		}
@@ -85,7 +107,7 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		// Requête autorisée : publie une contribution `rate` proportionnelle à la
 		// déplétion du bucket (pression de débit) pour le moteur de risque. Le 429
 		// volumétrique ci-dessus reste indépendant (cf. Articulation FR-35).
-		if contribution := rateContribution(snapshot.Tokens, effectiveCapacity); contribution > 0 {
+		if contribution := rateContribution(snapshot.Tokens, m.capacity); contribution > 0 {
 			r.Header.Set("X-WAF-Risk-rate", strconv.Itoa(maxInt(contribution, existingRateContribution(r))))
 		}
 
@@ -93,17 +115,17 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 	})
 }
 
-// loadBucket reconstruit le token bucket avec le débit/capacité EFFECTIFS du
-// moment (recalculés à chaque requête depuis la config × le facteur de pression),
+// loadBucket reconstruit le token bucket avec le débit de refill EFFECTIF du
+// moment (recalculé à chaque requête depuis la config × le facteur de pression),
 // jamais depuis les valeurs persistées. Seuls les jetons et l'instant de refill
 // sont repris du store : ainsi un resserrement sous pression est réversible dès
 // que la pression retombe, sans figer un débit réduit dans le stockage.
-func (m *Middleware) loadBucket(ipHash string, rate float64, capacity float64, now time.Time) *TokenBucket {
-	if existing, ok := m.store.GetBucket(ipHash); ok {
+func (m *Middleware) loadBucket(existing *storage.RateBucket, hasExisting bool, rate float64, capacity float64, now time.Time) *TokenBucket {
+	if hasExisting {
 		tokens := existing.Tokens
 		if tokens > capacity {
-			// La capacité effective a baissé (pression) : on rogne les jetons
-			// accumulés au plafond courant — c'est la mitigation immédiate.
+			// La capacité configurée a baissé depuis la persistance : rogne les
+			// jetons accumulés au plafond courant.
 			tokens = capacity
 		}
 		return BucketFromSnapshot(BucketSnapshot{
@@ -117,6 +139,32 @@ func (m *Middleware) loadBucket(ipHash string, rate float64, capacity float64, n
 	}
 
 	return NewTokenBucket(rate, capacity, now)
+}
+
+// nominalWouldAllow rejoue la requête refusée sur le bucket persisté avec le
+// débit de refill NOMINAL (sans facteur de pression), sans rien persister. Si
+// elle aurait été admise, le 429 courant est imputable au seul resserrement de
+// pression et doit rester neutre (FR-08). Approximation assumée : seul le
+// dernier intervalle de refill est rejoué au débit nominal ; un abuseur soutenu
+// reste largement au-dessus du nominal et échoue aussi ce rejeu.
+func (m *Middleware) nominalWouldAllow(existing *storage.RateBucket, hasExisting bool, now time.Time) bool {
+	if !hasExisting {
+		return true
+	}
+	tokens := existing.Tokens
+	if tokens > m.capacity {
+		tokens = m.capacity
+	}
+	nominal := BucketFromSnapshot(BucketSnapshot{
+		IPHash:     existing.IPHash,
+		Tokens:     tokens,
+		LastRefill: existing.LastRefill,
+		Rate:       m.rate,
+		Capacity:   m.capacity,
+		ExpiresAt:  existing.ExpiresAt,
+	})
+	allowed, _ := nominal.TryConsume(now)
+	return allowed
 }
 
 // pressureFactor retourne le multiplicateur appliqué au débit/capacité du bucket

--- a/internal/middleware/ratelimit/middleware_test.go
+++ b/internal/middleware/ratelimit/middleware_test.go
@@ -167,27 +167,132 @@ func TestMiddlewareSkipsWhitelistedRequests(t *testing.T) {
 	}
 }
 
-func TestPressureThrottlesUntrustedVisitor(t *testing.T) {
+func TestPressureThrottlesSustainedRateButKeepsBurst(t *testing.T) {
 	store := memory.New(100)
 	t.Cleanup(store.Close)
 
-	// rate=burst=20 ; sous pression critique (×0.25) la capacité effective
-	// tombe à 5 → seules 5 requêtes passent avant le THROTTLE (429).
+	// rate=burst=20 ; sous pression critique (×0.25) seul le débit de refill
+	// tombe à 5/s — le burst nominal est conservé : la rafale initiale passe
+	// entière, puis le débit soutenu est resserré.
 	middleware := newTestMiddleware(t, store, 20, 20)
 	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
 	middleware.now = func() time.Time { return now }
 	handler := middleware.Handler(countingHandler())
 
-	okCount := 0
+	burstOK := 0
+	for i := 0; i < 20; i++ {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
+		if response.Code == http.StatusNoContent {
+			burstOK++
+		}
+	}
+	if burstOK != 20 {
+		t.Fatalf("burstOK under critical pressure = %d, want 20 (nominal burst kept)", burstOK)
+	}
+
+	// Une seconde plus tard, le refill resserré (5/s) ne rend que 5 jetons.
+	now = now.Add(time.Second)
+	sustainedOK := 0
 	for i := 0; i < 8; i++ {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
 		if response.Code == http.StatusNoContent {
-			okCount++
+			sustainedOK++
 		}
 	}
-	if okCount != 5 {
-		t.Fatalf("okCount under critical pressure = %d, want 5 (20 × 0.25)", okCount)
+	if sustainedOK != 5 {
+		t.Fatalf("sustainedOK under critical pressure = %d, want 5 (20/s × 0.25)", sustainedOK)
+	}
+}
+
+func TestPressureThrottle429IsNeutral(t *testing.T) {
+	store := memory.New(100)
+	t.Cleanup(store.Close)
+
+	// rate=10, burst=1, pression critique (refill effectif 2.5/s). 200 ms après
+	// avoir vidé le bucket, le rejeu nominal rend 2 jetons (admis) mais le
+	// refill resserré n'en rend que 0.5 (refusé) : 429 imputable à la seule
+	// pression → reason dédiée, pas de pénalité de score.
+	middleware := newTestMiddleware(t, store, 10, 1)
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	middleware.now = func() time.Time { return now }
+	handler := middleware.Handler(countingHandler())
+
+	handler.ServeHTTP(httptest.NewRecorder(), requestWithPressure("9.9.9.9:1234", pressureCritical))
+
+	now = now.Add(200 * time.Millisecond)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
+
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", response.Code)
+	}
+	if got := response.Header().Get("X-WAF-Reason"); got != ReasonPressureThrottle {
+		t.Fatalf("X-WAF-Reason = %q, want %s", got, ReasonPressureThrottle)
+	}
+	visitor, ok := store.GetVisitor(trust.HashIP("9.9.9.9"))
+	if !ok {
+		t.Fatal("expected visitor to exist")
+	}
+	if visitor.Score != 50 {
+		t.Fatalf("score = %d, want 50 (no penalty for pressure-only 429)", visitor.Score)
+	}
+}
+
+func TestNominalExceededUnderPressureIsStillPenalized(t *testing.T) {
+	store := memory.New(100)
+	t.Cleanup(store.Close)
+
+	// Deux requêtes au même instant avec rate=burst=1 : la seconde dépasse le
+	// débit nominal lui-même — la pression n'exonère pas ce refus.
+	middleware := newTestMiddleware(t, store, 1, 1)
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	middleware.now = func() time.Time { return now }
+	handler := middleware.Handler(countingHandler())
+
+	handler.ServeHTTP(httptest.NewRecorder(), requestWithPressure("9.9.9.9:1234", pressureCritical))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
+
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", response.Code)
+	}
+	if got := response.Header().Get("X-WAF-Reason"); got != reasonRateLimitExceeded {
+		t.Fatalf("X-WAF-Reason = %q, want %s", got, reasonRateLimitExceeded)
+	}
+	visitor, ok := store.GetVisitor(trust.HashIP("9.9.9.9"))
+	if !ok {
+		t.Fatal("expected visitor to exist")
+	}
+	if visitor.Score != 40 {
+		t.Fatalf("score = %d, want 40 (nominal violation penalized)", visitor.Score)
+	}
+}
+
+func TestRateLimitPenaltyAppliedOncePerWindow(t *testing.T) {
+	store := memory.New(100)
+	t.Cleanup(store.Close)
+
+	middleware := newTestMiddleware(t, store, 1, 1)
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	middleware.now = func() time.Time { return now }
+	handler := middleware.Handler(countingHandler())
+
+	// 1 requête admise puis 15 refusées au même instant (cascade de
+	// sous-requêtes d'un même chargement de page) : UNE seule pénalité.
+	handler.ServeHTTP(httptest.NewRecorder(), requestFrom("9.9.9.9:1234"))
+	for i := 0; i < 15; i++ {
+		handler.ServeHTTP(httptest.NewRecorder(), requestFrom("9.9.9.9:1234"))
+	}
+	visitor, ok := store.GetVisitor(trust.HashIP("9.9.9.9"))
+	if !ok {
+		t.Fatal("expected visitor to exist")
+	}
+	// Le passage à la fenêtre suivante (nouvelle pénalité) est couvert par
+	// TestPenalizeRateLimitOncePerWindow (package trust, horloge simulée).
+	if visitor.Score != 40 {
+		t.Fatalf("score after 429 cascade = %d, want 40 (one penalty per window)", visitor.Score)
 	}
 }
 
@@ -252,18 +357,20 @@ func TestPressureThrottleIsReversible(t *testing.T) {
 	middleware.now = func() time.Time { return now }
 	handler := middleware.Handler(countingHandler())
 
-	// Épuise le bucket resserré sous pression critique.
-	for i := 0; i < 8; i++ {
+	// Épuise le burst nominal sous pression critique.
+	for i := 0; i < 20; i++ {
 		handler.ServeHTTP(httptest.NewRecorder(), requestWithPressure("6.6.6.6:1234", pressureCritical))
 	}
 
-	// La pression retombe : capacité nominale restaurée, le bucket refait le plein
-	// au débit nominal (20/s) → une requête passe à nouveau dès la seconde suivante.
+	// La pression retombe : le refill repart au débit nominal (20/s) → toute la
+	// rafale suivante passe dès la seconde suivante (au lieu de 5 sous pression).
 	now = now.Add(time.Second)
-	response := httptest.NewRecorder()
-	handler.ServeHTTP(response, requestWithPressure("6.6.6.6:1234", pressureNormal))
-	if response.Code != http.StatusNoContent {
-		t.Fatalf("status after pressure release = %d, want 204 (reversible)", response.Code)
+	for i := 0; i < 8; i++ {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, requestWithPressure("6.6.6.6:1234", pressureNormal))
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("request %d after pressure release: status = %d, want 204 (reversible)", i, response.Code)
+		}
 	}
 }
 

--- a/internal/storage/interface.go
+++ b/internal/storage/interface.go
@@ -3,21 +3,22 @@ package storage
 import "time"
 
 type VisitorState struct {
-	IPHash            string
-	Domain            string
-	Score             int
-	FirstSeen         time.Time
-	LastSeen          time.Time
-	ExpiresAt         time.Time
-	ReqCount          int64
-	ViolationCount    int
-	ChallengePassed   bool
-	ChallengeAttempts int
-	ChallengeFailures int
-	FPHash            *string
-	StickyTrustUntil  *time.Time
-	CircuitOpen       bool
-	CircuitOpenUntil  *time.Time
+	IPHash               string
+	Domain               string
+	Score                int
+	FirstSeen            time.Time
+	LastSeen             time.Time
+	ExpiresAt            time.Time
+	ReqCount             int64
+	ViolationCount       int
+	LastRateLimitPenalty *time.Time
+	ChallengePassed      bool
+	ChallengeAttempts    int
+	ChallengeFailures    int
+	FPHash               *string
+	StickyTrustUntil     *time.Time
+	CircuitOpen          bool
+	CircuitOpenUntil     *time.Time
 }
 
 type RateBucket struct {

--- a/internal/trust/score.go
+++ b/internal/trust/score.go
@@ -23,6 +23,11 @@ const (
 	DeltaRateLimit       = -10
 	DeltaChallengeFailed = -20
 	DeltaHoneypot        = -50
+
+	// RateLimitPenaltyWindow borne DeltaRateLimit à une application par fenêtre
+	// (FR-05) : les sous-requêtes refusées d'un même chargement de page comptent
+	// pour UNE pénalité, pas une par 429.
+	RateLimitPenaltyWindow = 10 * time.Second
 )
 
 type ScoreManager struct {
@@ -100,6 +105,23 @@ func (m *ScoreManager) Apply(ip string, domain string, delta int) storage.Visito
 	visitor.Score = clamp(visitor.Score+delta, 0, 100)
 	visitor.LastSeen = m.now()
 	visitor.ExpiresAt = visitor.LastSeen.Add(m.scoreTTL)
+	m.store.SetVisitor(visitor.IPHash, visitor)
+	return visitor
+}
+
+// PenalizeRateLimit applique DeltaRateLimit au plus une fois par
+// RateLimitPenaltyWindow (FR-05). Les refus supplémentaires dans la fenêtre
+// retournent l'état courant sans nouvelle pénalité.
+func (m *ScoreManager) PenalizeRateLimit(ip string, domain string) storage.VisitorState {
+	visitor := m.Get(ip, domain)
+	now := m.now()
+	if visitor.LastRateLimitPenalty != nil && now.Sub(*visitor.LastRateLimitPenalty) < RateLimitPenaltyWindow {
+		return visitor
+	}
+	visitor.Score = clamp(visitor.Score+DeltaRateLimit, 0, 100)
+	visitor.LastSeen = now
+	visitor.ExpiresAt = now.Add(m.scoreTTL)
+	visitor.LastRateLimitPenalty = &now
 	m.store.SetVisitor(visitor.IPHash, visitor)
 	return visitor
 }

--- a/internal/trust/score_test.go
+++ b/internal/trust/score_test.go
@@ -78,6 +78,30 @@ func TestScoreManagerResetsExpiredVisitor(t *testing.T) {
 	}
 }
 
+func TestPenalizeRateLimitOncePerWindow(t *testing.T) {
+	manager, store := newTestManager(t)
+	defer store.Close()
+
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	manager.Set("1.2.3.4", "example.test", 50)
+
+	if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 40 {
+		t.Fatalf("Score after first penalty = %d, want 40", visitor.Score)
+	}
+	// Refus supplémentaires dans la même fenêtre : aucune pénalité de plus.
+	for i := 0; i < 15; i++ {
+		if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 40 {
+			t.Fatalf("Score within window = %d, want 40 (single penalty per window)", visitor.Score)
+		}
+	}
+
+	now = now.Add(RateLimitPenaltyWindow)
+	if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 30 {
+		t.Fatalf("Score in next window = %d, want 30", visitor.Score)
+	}
+}
+
 func TestTrustMiddlewareBlocksBelowThreshold(t *testing.T) {
 	manager, store := newTestManager(t)
 	defer store.Close()

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -6,6 +6,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **FR-08/FR-05 (v2.1.0) — cascade de faux positifs sous pression** : pendant un
+  DDoS, un visiteur légitime était tué en un clic. Le throttle de pression
+  divisait aussi la **capacité de burst** (÷4 en critical) : un chargement de
+  page (25-50 sous-requêtes) crevait le bucket → chaque 429 appliquait -10 au
+  score jusqu'à BLOCKED (TTL 1 h) → les 429 nourrissaient le circuit-breaker
+  (5 consécutifs → 403 pendant 300 s). Corrections de spec :
+  - le throttle de pression réduit **uniquement le débit de refill**, jamais la
+    capacité de burst (le débit soutenu distingue un bot, pas le burst initial) ;
+  - un 429 imputable au seul throttle de pression est marqué
+    `reason=rate_limit_pressure` et reste **neutre** (ni violation breaker, ni
+    pénalité de score) ; un dépassement du débit nominal reste sanctionné ;
+  - la pénalité de score rate-limit est bornée à **une par fenêtre de 10 s**
+    (champ `last_rate_limit_penalty` dans visitor.schema.json) au lieu d'une
+    par sous-requête refusée.
+
 ### Security
 
 - Toolchain Go forcé à **`go1.26.5`** (directive `toolchain` dans `go.mod`) :

--- a/specs/features/anti-ddos.feature
+++ b/specs/features/anti-ddos.feature
@@ -66,6 +66,36 @@ Feature: Protection Anti-DDoS
     And le header "Retry-After" est présent dans la réponse 429
     And le log indique action="RATE_LIMIT"
 
+  Scenario: Pression critique — le burst nominal est conservé (chargement de page)
+    Given le WAF observe un trafic global critique
+    And un visiteur inconnu (non TRUSTED) avec un bucket plein
+    When son navigateur envoie 40 sous-requêtes en 1 seconde (un chargement de page)
+    Then toutes les sous-requêtes sont transmises à l'upstream
+    And seul le débit de refill est réduit par la pression, jamais la capacité de burst
+
+  Scenario: 429 de pression — neutre pour le breaker et le score
+    Given le WAF observe un trafic global critique
+    And un visiteur inconnu a épuisé son bucket au débit resserré par la pression
+    And la même requête aurait été admise au débit de refill nominal
+    When il envoie une nouvelle requête
+    Then la requête reçoit une réponse HTTP 429 avec reason="rate_limit_pressure"
+    And le score de confiance du visiteur n'est pas décrémenté
+    And le circuit-breaker n'enregistre pas de violation
+
+  Scenario: Dépassement du débit nominal sous pression — toujours sanctionné
+    Given le WAF observe un trafic global critique
+    And un visiteur inconnu envoie des requêtes au-delà de son débit nominal (hors pression)
+    When il envoie une nouvelle requête refusée
+    Then la requête reçoit une réponse HTTP 429 avec reason="rate_limit_exceeded"
+    And le score de confiance du visiteur est décrémenté
+    And le circuit-breaker enregistre une violation
+
+  Scenario: Pénalité de score bornée par fenêtre — un clic ne tue pas le visiteur
+    Given un visiteur avec l'IP "1.2.3.4" et un score de confiance de 50
+    When son navigateur déclenche 15 réponses 429 en moins de 10 secondes (sous-requêtes d'une même page)
+    Then le score du visiteur est décrémenté une seule fois (50 - 10 = 40)
+    And le visiteur n'atteint pas l'état BLOCKED à cause de cette seule cascade
+
   Scenario: Journalisation d'un événement de rate limiting
     Given un visiteur avec l'IP "5.5.5.5" déclenche le rate limit
     Then un événement de sécurité est journalisé

--- a/specs/features/trust-score.feature
+++ b/specs/features/trust-score.feature
@@ -33,6 +33,7 @@ Feature: Système de score de confiance
     When il déclenche le rate limit
     Then le score devient 45 (55 - 10)
     And la requête reçoit HTTP 429
+    And les 429 supplémentaires dans la même fenêtre de pénalité (10 s) ne décrémentent pas davantage le score
 
   Scenario: Honeypot touché — score à zéro
     Given un visiteur avec score = 80
@@ -48,7 +49,7 @@ Feature: Système de score de confiance
 
   Scenario: Transitions d'état — TRUSTED → CHALLENGED
     Given un visiteur avec score = 75 (état TRUSTED)
-    When il déclenche le rate limit 3 fois consécutives (3 × -10)
+    When il déclenche le rate limit dans 3 fenêtres de pénalité distinctes (3 × -10)
     Then le score devient 45 (75 - 30)
     And l'état reste "MONITORED"
     When il déclenche encore 1 violation (-10)

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -1,9 +1,9 @@
 ---
-status: implemented
-version: 2.0.0
-last-reviewed: 2026-06-09
+status: approved
+version: 2.1.0
+last-reviewed: 2026-07-18
 reviewed-by: GaetanDev
-change: "FR-08 remplace le blocage global 503 par un mode de pression adaptative"
+change: "FR-08 : le throttle de pression réduit le débit sans rogner le burst, et ses 429 ne nourrissent ni le circuit breaker ni la pénalité de score ; FR-05 : pénalité rate-limit au plus une fois par fenêtre (anti-cascade sous-requêtes)"
 ---
 
 # Requirements — WAF Anti-DDoS / Anti-Bot
@@ -44,6 +44,8 @@ change: "FR-08 remplace le blocage global 503 par un mode de pression adaptative
 - Score initial : 50 pour les nouveaux visiteurs
 - Augmentations : challenge JS réussi (+25), navigation normale (+1/req)
 - Diminutions : challenge JS échoué (-20), rate limit atteint (-10), user-agent suspect (-15), pattern bot (-30)
+- La pénalité « rate limit atteint » DOIT être appliquée **au plus une fois par fenêtre de pénalité** (10 s) : les sous-requêtes refusées d'un même chargement de page (CSS, JS, images, appels API) comptent pour UNE pénalité, pas une par 429 — sinon un seul clic suffit à faire passer un humain de 50 à BLOCKED
+- La pénalité « rate limit atteint » NE DOIT PAS s'appliquer à un 429 imputable au seul resserrement de pression globale (`rate_limit_pressure`, cf. FR-08) : la requête aurait été admise au débit nominal, le visiteur n'a rien fait d'anormal
 - Seuils d'action configurables :
   - `challenge_threshold` (défaut: 40) — en dessous : challenge JS requis
   - `block_threshold` (défaut: 10) — en dessous : blocage HTTP 403
@@ -79,6 +81,9 @@ change: "FR-08 remplace le blocage global 503 par un mode de pression adaptative
 - Le WAF DOIT calculer un niveau de pression global explicite : `normal`, `elevated`, `high`, `critical`
 - Le WAF NE DOIT PAS retourner HTTP 503, HTTP 403 ou ouvrir un blocage complet uniquement parce que le seuil global de trafic est dépassé
 - Le WAF DOIT utiliser la pression globale comme signal adaptatif pour renforcer les mitigations réversibles : contribution `rate`/`global_pressure`, challenge plus fréquent des visiteurs inconnus, difficulté PoW accrue, rate limit plus strict pour visiteurs inconnus ou suspects
+- Le resserrement du rate limit sous pression DOIT réduire uniquement le **débit de refill** (rate × facteur de pression) et conserver la **capacité de burst nominale** : un chargement de page unique (rafale de 25-50 sous-requêtes) DOIT passer même sous pression critique — c'est le débit soutenu qui distingue un bot, pas le burst initial
+- Un 429 imputable au seul resserrement de pression (la requête aurait été admise au débit de refill nominal) DOIT être identifié `reason=rate_limit_pressure` et DOIT rester **neutre** : ni violation de circuit-breaker, ni pénalité de score de confiance (FR-05) — sans quoi le WAF ouvre le circuit et bloque des humains à cause des 429 qu'il a lui-même provoqués (boucle de rétroaction auto-infligée)
+- Un 429 correspondant à un dépassement du débit nominal (`reason=rate_limit_exceeded`) DOIT continuer à compter comme violation de circuit-breaker et à pénaliser le score, y compris sous pression
 - Le WAF DOIT laisser les visiteurs connus, les visiteurs avec cookie valide et les bots vérifiés continuer selon les contrôles par IP, blacklist explicite, circuit-breaker et moteur de risque
 - Le WAF DOIT exposer le niveau de pression courant dans les logs et métriques afin de permettre l'alerte et la calibration
 

--- a/specs/schemas/visitor.schema.json
+++ b/specs/schemas/visitor.schema.json
@@ -47,6 +47,11 @@
       "minimum": 0,
       "description": "Nombre de violations (rate limit, honeypot, etc.)"
     },
+    "last_rate_limit_penalty": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Dernière application de la pénalité rate-limit (FR-05) — la pénalité est appliquée au plus une fois par fenêtre de 10 s"
+    },
     "challenge_passed": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
## Résumé

- Pendant un DDoS, un visiteur légitime était tué en un clic : le throttle de pression divisait aussi la **capacité de burst** (÷4 en `critical`), un chargement de page (25-50 sous-requêtes) crevait le bucket, chaque 429 appliquait `-10` au score jusqu'à `BLOCKED` (TTL 1 h), et ces mêmes 429 nourrissaient le circuit-breaker (5 consécutifs → 403 pendant 300 s) — boucle de rétroaction auto-infligée.
- Sous pression, seul le **débit de refill** est désormais resserré (`rate × facteur`) ; la **capacité de burst reste nominale**, donc un chargement de page unique passe toujours. Un 429 imputable au seul throttle est marqué `reason=rate_limit_pressure` et reste **neutre** : ni pénalité de score, ni violation de circuit-breaker. Un vrai dépassement du débit nominal (`rate_limit_exceeded`) reste sanctionné.
- La pénalité de score rate-limit est bornée à **une application par fenêtre de 10 s** (les sous-requêtes d'un même chargement comptent pour une pénalité), et les commentaires trompeurs de `pressure_levels` dans la config d'exemple sont corrigés (seuils = `baseline × multiplicateur`, pas des valeurs absolues).

## Références

- Spec : `specs/requirements.md` (FR-05 / FR-08, v2.0.0 → **v2.1.0**)
- Spec : `specs/features/anti-ddos.feature`, `specs/features/trust-score.feature`
- Schéma : `specs/schemas/visitor.schema.json` (champ `last_rate_limit_penalty`)
- Changelog : `specs/changelog.md` → `[Unreleased] > Fixed`
- Contexte : incident DDoS L7 distribué du 2026-06-19 ; complète FR-39 / ADR-018 (mode sous attaque)

---

## Checklist SDD — 7 gates

### Spécification
- [x] **G0 — Spec** : spec mise à jour avant le code (commit `spec(...) [spec only]` séparé du commit `fix(...)`)
- [x] **G0 — Pas de breaking change silencieux** : changement de comportement de mitigation borné par bump MINOR documenté (v2.0.0 → v2.1.0) ; comportement conforme à ADR-016 (aucun blocage dur nouveau, mitigation assouplie). Pas de nouvel ADR : la décision reste dans le cadre d'ADR-016.

### Qualité technique
- [ ] **G1 — Spec lint** : `spectral` non installé localement — à valider en CI
- [x] **G2 — Type check** : `go build ./...` + `go vet ./...` sans erreur
- [x] **G3 — Conformance API** : les 429 conservent status + `Retry-After` ; seule la valeur `X-WAF-Reason` se scinde en `rate_limit_pressure` / `rate_limit_exceeded`
- [x] **G4 — Tests** : `go test ./...` → **350 tests OK** ; nouveaux tests sur chaque comportement (burst conservé, 429 de pression neutre, dépassement nominal sanctionné, pénalité bornée, streak breaker préservée)
- [x] **G5 — Sécurité** : aucun nouveau `nolint`, aucun secret ; assouplit une mitigation sans réduire les contrôles déterministes

### Release
- [x] **G6 — Performance** : chemin par requête inchangé en coût (un rejeu de bucket en O(1) uniquement sur un refus déjà sous pression) ; aucune I/O ajoutée
- [ ] **G7 — Review humaine** : en attente de reviewer

---

## Plan de test

- [x] `go test ./internal/...` → 350 passed
- [x] Sous pression `critical`, une rafale de 20 requêtes (burst nominal) passe entière, puis le débit soutenu tombe à `rate × 0.25`
- [x] Un 429 de pression n'ouvre jamais le circuit, même au-delà du seuil de violations, et ne décrémente pas le score
- [x] Un dépassement du débit nominal sous pression reste pénalisé (`rate_limit_exceeded`, score `-10`, violation breaker)
- [x] Une cascade de 15 sous-requêtes refusées dans la même fenêtre ne coûte que `-10` au score
- [ ] Vérification en prod après redéploiement du binaire (config prod à recalibrer côté commentaires)

## Captures / logs

```
Go vet: No issues found
Go build: Success
Go test: 350 passed in 39 packages
```
