### PR TITLE
fix(logger): sanitize Cloudflare CF-Ray/CF-IPCountry before logging (code-scanning #35/#36)

### DIFF
--- a/internal/logger/middleware.go
+++ b/internal/logger/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gaetandev/waf/internal/alert"
@@ -125,8 +126,8 @@ func (l Logger) securityEvent(r *http.Request, recorder *statusRecorder, scores 
 		LatencyMS:      elapsedMS,
 		WAFLatencyMS:   wafLatencyMS,
 		UpstreamStatus: upstreamStatus(action, recorder.statusCode),
-		CFRay:          optionalHeader(r, "CF-Ray"),
-		CFCountry:      optionalHeader(r, "CF-IPCountry"),
+		CFRay:          cfRay(r),
+		CFCountry:      cfCountry(r),
 	}
 }
 
@@ -213,12 +214,81 @@ func upstreamStatus(action string, statusCode int) *int {
 	return &statusCode
 }
 
-func optionalHeader(r *http.Request, name string) *string {
-	value := r.Header.Get(name)
+// maxCFRayLen plafonne la longueur d'un identifiant CF-Ray journalisé. Un ray
+// Cloudflare réel fait ~20 caractères (16 hexadécimaux + "-" + code datacenter) ;
+// la borne empêche un client joignant l'origine hors Cloudflare de forger une
+// valeur démesurée dans le journal d'audit.
+const maxCFRayLen = 32
+
+// cfRay lit et assainit l'en-tête CF-Ray (identifiant de corrélation Cloudflare),
+// contrôlable par un client atteignant directement l'origine (hors Cloudflare).
+// Le nom d'en-tête est un littéral constant : c'est ce qui lève l'alerte
+// clear-text-logging (CWE-312), CodeQL ne reconnaissant pas comme sûre une lecture
+// d'en-tête au nom variable. Le filtrage (alphanumériques ASCII + tiret, longueur
+// bornée) est une défense en profondeur contre l'injection de caractères de
+// contrôle chez les consommateurs de logs non-JSON (CWE-117).
+func cfRay(r *http.Request) *string {
+	return sanitizedToken(r.Header.Get("CF-Ray"), maxCFRayLen)
+}
+
+// cfCountry lit et assainit l'en-tête CF-IPCountry. Seul un code de 2 lettres
+// majuscules (ISO 3166-1 alpha-2 et "XX" — inconnu) ou la valeur spéciale
+// Cloudflare "T1" (Tor) est accepté ; toute autre valeur est ignorée (nil)
+// plutôt que journalisée telle quelle.
+func cfCountry(r *http.Request) *string {
+	country := strings.ToUpper(strings.TrimSpace(r.Header.Get("CF-IPCountry")))
+	if !isCountryCode(country) {
+		return nil
+	}
+	return &country
+}
+
+// sanitizedToken ne conserve que les caractères alphanumériques ASCII et le tiret,
+// dans la limite de maxLen. Retourne nil si la valeur est vide ou ne contient
+// aucun caractère autorisé.
+func sanitizedToken(value string, maxLen int) *string {
 	if value == "" {
 		return nil
 	}
-	return &value
+	var b strings.Builder
+	for _, c := range value {
+		if b.Len() >= maxLen {
+			break
+		}
+		if isTokenRune(c) {
+			b.WriteRune(c)
+		}
+	}
+	if b.Len() == 0 {
+		return nil
+	}
+	out := b.String()
+	return &out
+}
+
+// isTokenRune autorise les caractères d'un identifiant opaque sûr à journaliser.
+func isTokenRune(c rune) bool {
+	return c == '-' ||
+		(c >= '0' && c <= '9') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z')
+}
+
+// isCountryCode valide un code pays CF-IPCountry : 2 lettres majuscules ASCII
+// (codes ISO 3166-1 alpha-2 et "XX" inconnu) ou la valeur spéciale "T1" (Tor).
+func isCountryCode(s string) bool {
+	if s == "T1" {
+		return true
+	}
+	if len(s) != 2 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c < 'A' || c > 'Z' {
+			return false
+		}
+	}
+	return true
 }
 
 type statusRecorder struct {

--- a/internal/logger/middleware_test.go
+++ b/internal/logger/middleware_test.go
@@ -233,6 +233,109 @@ func TestSecurityEventJSONStaysWithinSchema(t *testing.T) {
 	}
 }
 
+// Un CF-Ray et un CF-IPCountry bien formés (trafic Cloudflare légitime) sont
+// journalisés tels quels, le code pays étant normalisé en majuscules.
+func TestMiddlewareLogsWellFormedCloudflareHeaders(t *testing.T) {
+	var output bytes.Buffer
+	log := NewWithWriter(config.Default().Logging, &output)
+	scores, store := newTestScoreManager(t)
+	defer store.Close()
+	handler := log.Middleware(scores, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	request.RemoteAddr = "1.2.3.4:1234"
+	request.Header.Set("CF-Ray", "8f2a1b3c4d5e6f70-CDG")
+	request.Header.Set("CF-IPCountry", "fr")
+
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	event := decodeEvent(t, output.String())
+	if event["cf_ray"] != "8f2a1b3c4d5e6f70-CDG" {
+		t.Fatalf("cf_ray = %v, want 8f2a1b3c4d5e6f70-CDG", event["cf_ray"])
+	}
+	if event["cf_country"] != "FR" {
+		t.Fatalf("cf_country = %v, want FR (normalisé en majuscules)", event["cf_country"])
+	}
+}
+
+// Un client atteignant l'origine hors Cloudflare peut forger ces en-têtes : la
+// valeur ne doit jamais atteindre le journal telle quelle. Les caractères de
+// contrôle / injection sont retirés du CF-Ray, et un code pays non conforme est
+// abandonné (null) plutôt que journalisé (log forging, CWE-117).
+func TestMiddlewareSanitizesForgedCloudflareHeaders(t *testing.T) {
+	var output bytes.Buffer
+	log := NewWithWriter(config.Default().Logging, &output)
+	scores, store := newTestScoreManager(t)
+	defer store.Close()
+	handler := log.Middleware(scores, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	request.RemoteAddr = "1.2.3.4:1234"
+	// Tentative d'injection d'une fausse ligne de log via CF-Ray.
+	request.Header.Set("CF-Ray", "abc\r\n{\"action\":\"forged\"} DROP")
+	// Code pays invalide (trop long + caractères de contrôle).
+	request.Header.Set("CF-IPCountry", "F\nR!")
+
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	event := decodeEvent(t, output.String())
+	// slog échappe déjà les caractères de contrôle dans le JSON ; l'assertion
+	// forte est que la valeur journalisée est exactement la forme filtrée,
+	// débarrassée des sauts de ligne, guillemets, accolades et espaces injectés.
+	if event["cf_ray"] != "abcactionforgedDROP" {
+		t.Fatalf("cf_ray = %v, want abcactionforgedDROP (valeur filtrée)", event["cf_ray"])
+	}
+	if event["cf_country"] != nil {
+		t.Fatalf("cf_country = %v, want null (code pays forgé rejeté)", event["cf_country"])
+	}
+}
+
+// TestSanitizedTokenAndCountryCode verrouille le comportement des primitives
+// d'assainissement, y compris les cas limites non couverts par le middleware.
+func TestSanitizedTokenAndCountryCode(t *testing.T) {
+	if got := sanitizedToken("", maxCFRayLen); got != nil {
+		t.Fatalf("sanitizedToken(vide) = %q, want nil", *got)
+	}
+	if got := sanitizedToken("!!!@@@ \n", maxCFRayLen); got != nil {
+		t.Fatalf("sanitizedToken(aucun caractère autorisé) = %q, want nil", *got)
+	}
+
+	for _, valid := range []string{"FR", "US", "XX", "T1"} {
+		if !isCountryCode(valid) {
+			t.Fatalf("isCountryCode(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"", "F", "FRA", "fr", "F1", "00", "9Z", "T2", "F R"} {
+		if isCountryCode(invalid) {
+			t.Fatalf("isCountryCode(%q) = true, want false", invalid)
+		}
+	}
+}
+
+// Un CF-Ray démesuré (client hors Cloudflare) est tronqué à maxCFRayLen.
+func TestMiddlewareCapsOversizedCFRay(t *testing.T) {
+	var output bytes.Buffer
+	log := NewWithWriter(config.Default().Logging, &output)
+	scores, store := newTestScoreManager(t)
+	defer store.Close()
+	handler := log.Middleware(scores, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	request.RemoteAddr = "1.2.3.4:1234"
+	request.Header.Set("CF-Ray", strings.Repeat("a", 500))
+
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	event := decodeEvent(t, output.String())
+	rayVal, _ := event["cf_ray"].(string)
+	if len(rayVal) != maxCFRayLen {
+		t.Fatalf("cf_ray length = %d, want %d (tronqué)", len(rayVal), maxCFRayLen)
+	}
+}
+
 func decodeEvent(t *testing.T, raw string) map[string]any {
 	t.Helper()
 

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -25,6 +25,29 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Security
 
+- Alertes code-scanning n°35/36 (`go/clear-text-logging`, CWE-312, HIGH)
+  **corrigées** : les en-têtes Cloudflare `CF-Ray` et `CF-IPCountry` étaient lus
+  via le helper générique `optionalHeader(r, name)` au **nom d'en-tête variable**,
+  puis journalisés tels quels dans l'événement de sécurité. CodeQL ne reconnaît
+  pas une lecture d'en-tête au nom non constant comme « en-tête non sensible »
+  (barrière `NonSensitiveHeaderGet`) et classait donc la valeur comme donnée
+  sensible atteignant un sink de log — contrairement à `reason`, `risk_decision`
+  ou `global_pressure`, lus avec un nom littéral et jamais signalés. Ces en-têtes
+  sont par ailleurs **contrôlables par le client** si l'origine est jointe hors
+  Cloudflare (accès direct). Correctifs (`internal/logger/middleware.go` ; contrat
+  `security-event.schema.json` inchangé — `cf_ray`/`cf_country` restent
+  `["string","null"]`) :
+  - lecture via un **nom d'en-tête littéral constant** : c'est ce qui lève
+    l'alerte (la barrière CodeQL s'applique) ;
+  - défense en profondeur : `cf_ray` **filtré** sur un jeu de caractères sûr
+    (alphanumériques ASCII + tiret) et borné à 32 caractères ; `cf_country`
+    **validé** (2 lettres majuscules — ISO 3166-1 alpha-2 et `XX` — ou `T1`
+    Cloudflare/Tor), sinon journalisé `null` plutôt que brut. Durcit aussi la
+    valeur pays transmise au webhook Discord (texte brut).
+  - Le journal d'audit transitant par le handler JSON de slog (échappement des
+    caractères de contrôle), l'injection de fausses lignes (CWE-117) n'y était
+    pas directement exploitable ; le filtrage protège les consommateurs de logs
+    non-JSON en aval.
 - Toolchain Go forcé à **`go1.26.5`** (directive `toolchain` dans `go.mod`) :
   corrige GO-2026-5856 (fuite de confidentialité Encrypted Client Hello dans
   `crypto/tls`, stdlib), **atteignable** dans le WAF (terminaison TLS,


### PR DESCRIPTION
## Contexte

Corrige les deux alertes **code-scanning** ouvertes (CodeQL `go/clear-text-logging`, **CWE-312**, sévérité **HIGH**) :

| # | Règle | Fichier | Ligne |
|---|---|---|---|
| [#35](https://github.com/GaetanOff/WAF-GaetanDev/security/code-scanning/35) | `go/clear-text-logging` | `internal/logger/logger.go` | 111 (`cf_ray`) |
| [#36](https://github.com/GaetanOff/WAF-GaetanDev/security/code-scanning/36) | `go/clear-text-logging` | `internal/logger/logger.go` | 112 (`cf_country`) |

## Cause racine

`CF-Ray` et `CF-IPCountry` étaient lus via le helper générique `optionalHeader(r, name)`, dont l'argument **nom d'en-tête est une variable**. CodeQL n'applique sa barrière `NonSensitiveHeaderGet` (« cet en-tête n'est pas sensible ») que lorsque le nom d'en-tête est une **constante littérale** — la lecture au nom variable était donc classée comme donnée sensible atteignant un sink de log. C'est aussi pourquoi `reason`, `risk_decision`, `global_pressure` (lus avec un littéral, journalisés au même endroit) n'ont jamais été signalés.

Ces en-têtes sont par ailleurs **contrôlables par le client** si l'origine est jointe directement (hors Cloudflare).

## Correctif

- **Lecture avec un nom d'en-tête littéral constant** (`r.Header.Get("CF-Ray")` / `r.Header.Get("CF-IPCountry")`) → la barrière CodeQL s'applique : **c'est ce qui lève l'alerte**. Le helper `optionalHeader` devenu mort est supprimé.
- **Défense en profondeur** (assainissement) :
  - `cf_ray` filtré sur un jeu de caractères sûr `[0-9A-Za-z-]` et borné à **32 caractères** ;
  - `cf_country` validé comme code de **2 lettres majuscules** (ISO 3166-1 alpha-2, `XX`) ou la valeur spéciale Cloudflare `T1` (Tor), sinon journalisé `null`.
  - Durcit aussi la valeur pays transmise au **webhook Discord** (texte brut).

> Note : le journal d'audit transitant par le handler JSON de `slog` (qui échappe les caractères de contrôle), l'injection de fausses lignes (CWE-117) n'y était pas directement exploitable ; le filtrage protège les consommateurs de logs non-JSON en aval.

## Conformité

- **Contrat inchangé** : `cf_ray`/`cf_country` restent `["string","null"]` dans `specs/schemas/security-event.schema.json` — pas de bump de version ni d'ADR requis.
- Entrée `### Security` ajoutée à `specs/changelog.md`.

## Tests / Gates

- 3 tests ajoutés (`internal/logger/middleware_test.go`) : en-têtes bien formés journalisés/normalisés, valeurs forgées assainies/rejetées, plafond de longueur, cas limites des primitives.
- `gofmt`, `go vet ./internal/logger/`, `go build ./...`, `go test ./internal/logger/... -race` → **verts** (12 tests).

> ⚠️ Hors périmètre : `TestPenalizeRateLimitOncePerWindow` (`internal/trust`) échoue **déjà sur `main`** (travail FR-08/FR-05 v2.1.0), indépendamment de ce correctif — laissé intact, à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)