### PR TITLE
fix(trust): share one test clock across score manager and store

### DIFF
--- a/internal/middleware/challenge/middleware_test.go
+++ b/internal/middleware/challenge/middleware_test.go
@@ -165,7 +165,8 @@ func TestMiddlewareVerifyInvalidPowDecrementsScore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateForRedirect() error = %v", err)
 	}
-	request := verifyRequest(t, "3.3.3.3:1234", submissionJSON(token, "0", 1200))
+	nonce := failPow(t, token, middleware.difficulty)
+	request := verifyRequest(t, "3.3.3.3:1234", submissionJSON(token, nonce, 1200))
 	response := httptest.NewRecorder()
 
 	middleware.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).ServeHTTP(response, request)
@@ -351,5 +352,22 @@ func solvePow(t *testing.T, token string, difficultyBits int) string {
 		}
 	}
 	t.Fatal("could not solve PoW")
+	return ""
+}
+
+// failPow retourne un nonce dont le hash NE satisfait PAS la difficulté : un PoW
+// invalide déterministe (miroir de solvePow). Un nonce codé en dur comme "0"
+// satisfait ~1/256 des tokens à difficulté 8 ; comme le token est horodaté (donc
+// non déterministe), cela rendait le test "invalid PoW" flaky en CI (~0,4 %).
+func failPow(t *testing.T, token string, difficultyBits int) string {
+	t.Helper()
+	for nonce := uint64(0); nonce < 10_000_000; nonce++ {
+		nonceText := strconv.FormatUint(nonce, 10)
+		sum := sha256.Sum256([]byte(token + nonceText))
+		if !hasLeadingZeroBits(sum[:], difficultyBits) {
+			return nonceText
+		}
+	}
+	t.Fatal("could not find invalid PoW")
 	return ""
 }

--- a/internal/storage/memory/store.go
+++ b/internal/storage/memory/store.go
@@ -25,7 +25,23 @@ type Store struct {
 	done chan struct{}
 }
 
-func New(maxVisitors int) *Store {
+// Option configure un Store à la construction.
+type Option func(*Store)
+
+// WithClock injecte l'horloge du Store. Sert à partager UNE horloge entre le
+// Store et le ScoreManager (tests déterministes) : l'éviction (ExpiresAt) et le
+// scoring lisent alors le même temps. Sans ça, un Store sur time.Now peut évincer
+// un visiteur que le manager, tournant sur une horloge injectée, croit encore
+// vivant. Un now nil est ignoré (l'horloge par défaut time.Now est conservée).
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+func New(maxVisitors int, opts ...Option) *Store {
 	if maxVisitors < 1 {
 		maxVisitors = 1
 	}
@@ -36,6 +52,9 @@ func New(maxVisitors int) *Store {
 		lru:         list.New(),
 		lruIndex:    make(map[string]*list.Element),
 		done:        make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(store)
 	}
 	go store.cleanupLoop()
 

--- a/internal/trust/score_test.go
+++ b/internal/trust/score_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestScoreManagerInitializesNewVisitor(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, _ := newTestManager(t)
 	defer store.Close()
 
 	visitor := manager.Get("4.4.4.4", "example.test")
@@ -25,7 +25,7 @@ func TestScoreManagerInitializesNewVisitor(t *testing.T) {
 }
 
 func TestScoreManagerApplyDeltaAndClamp(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, _ := newTestManager(t)
 	defer store.Close()
 
 	manager.Set("1.2.3.4", "example.test", 35)
@@ -41,7 +41,7 @@ func TestScoreManagerApplyDeltaAndClamp(t *testing.T) {
 }
 
 func TestScoreManagerStateTransitions(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, _ := newTestManager(t)
 	defer store.Close()
 
 	tests := []struct {
@@ -63,14 +63,13 @@ func TestScoreManagerStateTransitions(t *testing.T) {
 }
 
 func TestScoreManagerResetsExpiredVisitor(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, clock := newTestManager(t)
 	defer store.Close()
 
-	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
-	manager.now = func() time.Time { return now }
+	clock.set(time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
 	manager.Set("8.8.8.8", "example.test", 90)
 
-	now = now.Add(65 * time.Minute)
+	clock.advance(65 * time.Minute) // au-delà du score_ttl (1h) : l'entrée expire
 	visitor := manager.Get("8.8.8.8", "example.test")
 
 	if visitor.Score != 50 {
@@ -79,11 +78,10 @@ func TestScoreManagerResetsExpiredVisitor(t *testing.T) {
 }
 
 func TestPenalizeRateLimitOncePerWindow(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, clock := newTestManager(t)
 	defer store.Close()
 
-	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
-	manager.now = func() time.Time { return now }
+	clock.set(time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC))
 	manager.Set("1.2.3.4", "example.test", 50)
 
 	if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 40 {
@@ -96,14 +94,14 @@ func TestPenalizeRateLimitOncePerWindow(t *testing.T) {
 		}
 	}
 
-	now = now.Add(RateLimitPenaltyWindow)
+	clock.advance(RateLimitPenaltyWindow)
 	if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 30 {
 		t.Fatalf("Score in next window = %d, want 30", visitor.Score)
 	}
 }
 
 func TestTrustMiddlewareBlocksBelowThreshold(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, _ := newTestManager(t)
 	defer store.Close()
 	manager.Set("9.9.9.9", "example.test", 2)
 
@@ -121,7 +119,7 @@ func TestTrustMiddlewareBlocksBelowThreshold(t *testing.T) {
 }
 
 func TestTrustMiddlewareMarksChallengeState(t *testing.T) {
-	manager, store := newTestManager(t)
+	manager, store, _ := newTestManager(t)
 	defer store.Close()
 	manager.Set("9.9.9.9", "example.test", 25)
 
@@ -143,10 +141,23 @@ func TestTrustMiddlewareMarksChallengeState(t *testing.T) {
 	}
 }
 
-func newTestManager(t *testing.T) (*ScoreManager, *memory.Store) {
+// fakeClock est une horloge mutable partagée par le ScoreManager et le Store en
+// test. Le stamping du TTL (ExpiresAt) et l'éviction du Store lisent ainsi le
+// MÊME temps : câbler le Store sur time.Now pendant que le manager tourne sur une
+// horloge injectée laissait le Store évincer des visiteurs que le manager croyait
+// encore vivants — un date-bomb où un test figé dans le passé cassait au fil du
+// temps réel.
+type fakeClock struct{ current time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.current }
+func (c *fakeClock) set(t time.Time)         { c.current = t }
+func (c *fakeClock) advance(d time.Duration) { c.current = c.current.Add(d) }
+
+func newTestManager(t *testing.T) (*ScoreManager, *memory.Store, *fakeClock) {
 	t.Helper()
 
-	store := memory.New(100)
+	clock := &fakeClock{current: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	store := memory.New(100, memory.WithClock(clock.now))
 	cfg := config.Default()
 	cfg.Version = "1.0"
 	cfg.Server.Listen = ":0"
@@ -158,5 +169,6 @@ func newTestManager(t *testing.T) (*ScoreManager, *memory.Store) {
 	if err != nil {
 		t.Fatalf("NewScoreManager() error = %v", err)
 	}
-	return manager, store
+	manager.now = clock.now // horloge partagée : éviction et scoring d'accord
+	return manager, store, clock
 }


### PR DESCRIPTION
## Résumé

- Corrige `TestPenalizeRateLimitOncePerWindow` (paquet `internal/trust`), un **date-bomb** : `newTestManager` injectait une horloge factice dans le `ScoreManager` mais construisait le `memory.Store` sur `time.Now` réel. Le manager estampillait `VisitorState.ExpiresAt` à la date figée `2026-07-18`, tandis que le store évinçait sur l'horloge murale — une fois le temps réel passé cette date, le store droppait le visiteur à la lecture et le score final tombait à 40 au lieu de 30.
- Ajoute une option `WithClock` à `memory.Store` (le défaut reste `time.Now`, donc **aucun impact prod** — `cmd/waf` inchangé) et **partage UNE seule horloge** entre le `ScoreManager` et le `Store` dans `newTestManager`. Éviction et scoring lisent désormais le même temps ; les deux tests pilotés par le temps avancent l'horloge partagée au lieu d'une date absolue.
- Débloque le gate CI **Test (race + coverage)**, qui rougissait sur chaque PR à cause de ce test.
- **2ᵉ commit — `test(challenge)`** : dé-flake `TestMiddlewareVerifyInvalidPowDecrementsScore`, un flake **préexistant** (indépendant du fix trust). Le test envoyait un nonce `"0"` codé en dur, valide au PoW 8 bits pour ~1/256 des tokens (horodatés, donc non déterministes) → 200 au lieu de 400 (~0,4 % des runs). Remplacé par un helper `failPow` (miroir de `solvePow`) qui produit un nonce déterministiquement invalide.

## Références

- Contrat : `specs/schemas/visitor.schema.json` (`expires_at`, `last_rate_limit_penalty`) — comportement FR-05 (pénalité rate-limit au plus une fois par fenêtre) inchangé.
- Aucune spec modifiée, aucune issue à fermer.

---

## Checklist SDD — 7 gates

### Spécification
- [x] **G0 — Spec** : N/A — aucune nouvelle fonctionnalité ni changement de contrat (fix de câblage d'horloge en test + option additive).
- [x] **G0 — Pas de breaking change silencieux** : `WithClock` est additif, comportement par défaut identique (`time.Now`).

### Qualité technique
- [x] **G1 — Spec lint** : N/A — aucun fichier `specs/` touché.
- [x] **G2 — Type check** : `go build ./...` + `go vet ./internal/storage/memory/ ./internal/trust/` — sans erreur.
- [x] **G3 — Conformance API** : N/A — aucun changement d'endpoint/HTTP.
- [x] **G4 — Tests** : `go test ./... -race -count=1` → **368 passed / 40 packages**. Le code prod ajouté (`WithClock`) est exercé par les tests `trust` ; le chemin par défaut reste couvert par les tests `memory`.
- [x] **G5 — Sécurité** : aucun secret, aucun nouveau `nolint`/`nosemgrep`.

### Release
- [x] **G6 — Performance** : N/A — changement test-only + option no-op en prod.
- [ ] **G7 — Review humaine** : à faire par le reviewer.

---

## Plan de test

- [x] `go test ./internal/trust/ -run TestPenalizeRateLimitOncePerWindow -count=1` → **pass** (échouait avant : `Score in next window = 40, want 30`).
- [x] `go test ./... -race -count=1` → 368 passed, 40 packages.
- [x] `go build ./...`, `go vet`, `gofmt -l` sur les 2 fichiers → propres.

## Notes pour le reviewer

- `internal/risk/human_test.go` présente le **même antipattern** d'horloge scindée, masqué aujourd'hui en datant les fixtures en **2126** (l'`ExpiresAt` lointain n'expire jamais sous l'horloge réelle). Non corrigé ici pour garder la PR ciblée — candidat à un suivi avec le nouveau `WithClock`.
- `internal/middleware/ratelimit/middleware.go:78` estampille l'`ExpiresAt` du bucket avec `time.Now()` réel (pas `m.now()`) : no-op en prod, mais incohérence d'horloge qui « protège » ses tests par coïncidence. Hors périmètre.
