### PR TITLE
chore(go): adopt Go 1.27 across the codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          # golangci-lint v2 — v1 is EOL and cannot target Go 1.26.
+          # golangci-lint v2 — v1 is EOL and cannot target Go 1.27.
           # `latest` guarantees a build compiled with Go >= the module's
-          # toolchain (1.26); pin once a v2 release built with 1.26 is known.
+          # toolchain (1.27); pin once a v2 release built with 1.27 is known.
           version: latest
 
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- Build stage -----------------------------------------------------------
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 WORKDIR /src
 

--- a/cmd/waf/main.go
+++ b/cmd/waf/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -440,8 +441,8 @@ func routes(cfg config.Config, accessRules *access.RuleSet, securityLogger waflo
 	}
 	// Détecteurs avancés exécutés juste avant le moteur de risque (wrap en ordre
 	// inverse pour préserver l'ordre d'exécution detectors[0], detectors[1], ...).
-	for i := len(detectors) - 1; i >= 0; i-- {
-		proxyHandler = detectors[i](proxyHandler)
+	for _, detector := range slices.Backward(detectors) {
+		proxyHandler = detector(proxyHandler)
 	}
 	proxyHandler = antiBot.Handler(proxyHandler)
 	if cfg.RateLimit.Enabled {
@@ -529,8 +530,8 @@ func hostAllowed(host string, patterns []string) bool {
 }
 
 func stripPort(hostport string) string {
-	if colon := strings.IndexByte(hostport, ':'); colon >= 0 {
-		return hostport[:colon]
+	if before, _, ok := strings.Cut(hostport, ":"); ok {
+		return before
 	}
 	return hostport
 }

--- a/cmd/waf/main.go
+++ b/cmd/waf/main.go
@@ -305,6 +305,9 @@ func run() error {
 		ReadTimeout:       readTimeout,
 		WriteTimeout:      writeTimeout,
 		IdleTimeout:       idleTimeout,
+		// FR-23 : borne le coût de parsing d'une requête portant des milliers de
+		// lignes d'en-tête, en amont de tout middleware.
+		MaxHeaderValueCount: cfg.Server.MaxHeaderValueCount,
 	}
 	// ACME / Let's Encrypt (FR-31) : TLS direct avec renouvellement automatique
 	// (~30j avant expiration) et rotation à chaud via autocert.
@@ -356,9 +359,10 @@ func run() error {
 	// Serveur HTTP-01 (challenge ACME + redirection HTTPS) sur le port 80.
 	if acmeManager != nil {
 		challengeServer := &http.Server{
-			Addr:              cfg.ACME.HTTPChallengeListen,
-			Handler:           acmeManager.HTTPHandler(nil),
-			ReadHeaderTimeout: headerTimeout,
+			Addr:                cfg.ACME.HTTPChallengeListen,
+			Handler:             acmeManager.HTTPHandler(nil),
+			ReadHeaderTimeout:   headerTimeout,
+			MaxHeaderValueCount: cfg.Server.MaxHeaderValueCount,
 		}
 		go func() {
 			if err := challengeServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -371,9 +375,10 @@ func run() error {
 	// domaine et que redirect_http est actif.
 	if tlsManager != nil && cfg.Server.TLS.RedirectHTTP {
 		redirectServer := &http.Server{
-			Addr:              cfg.Server.Listen,
-			Handler:           redirectToHTTPS(cfg.Domains),
-			ReadHeaderTimeout: headerTimeout,
+			Addr:                cfg.Server.Listen,
+			Handler:             redirectToHTTPS(cfg.Domains),
+			ReadHeaderTimeout:   headerTimeout,
+			MaxHeaderValueCount: cfg.Server.MaxHeaderValueCount,
 		}
 		go func() {
 			if err := redirectServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -14,6 +14,10 @@ server:
   write_timeout: "30s"
   idle_timeout: "60s"
   graceful_shutdown_timeout: "15s"
+  # FR-23 — borne le nombre de valeurs d'en-tête par requête (Go 1.27+).
+  # Un navigateur en envoie ~20-30 ; 100 laisse de la marge tout en coupant les
+  # requêtes à des milliers de lignes d'en-tête. 0 = défaut Go (500).
+  max_header_value_count: 100
   # Terminaison TLS par domaine (FR-33) : opt-in, si le WAF n'est PAS derrière
   # un terminateur TLS amont. Le certificat est choisi par SNI via domains[].tls.
   tls:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/gaetandev/waf
 
-go 1.26.0
-
-// GO-2026-5856 (fuite ECH dans crypto/tls, atteignable : le WAF termine le
-// TLS) est corrigé dans la stdlib de go1.26.5 — forcer ce toolchain minimum.
-toolchain go1.26.5
+// Plancher de version à go1.27.0 : la directive `go` fait elle-même office de
+// toolchain minimum, et go1.27.0 embarque le correctif GO-2026-5856 (fuite ECH
+// dans crypto/tls, atteignable : le WAF termine le TLS) livré en go1.26.5.
+go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ module github.com/gaetandev/waf
 go 1.27.0
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.7.3
 	golang.org/x/crypto v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/adaptive/adaptive.go
+++ b/internal/adaptive/adaptive.go
@@ -96,10 +96,7 @@ func (c *Controller) Difficulty() int {
 	c.currentBits = decay(c.currentBits, target, now.Sub(c.lastDecay), c.tau)
 	c.lastDecay = now
 
-	difficulty := c.baseDifficulty + int(math.Round(c.currentBits))
-	if difficulty > c.maxDifficulty {
-		difficulty = c.maxDifficulty
-	}
+	difficulty := min(c.baseDifficulty+int(math.Round(c.currentBits)), c.maxDifficulty)
 	if difficulty < c.baseDifficulty {
 		difficulty = c.baseDifficulty
 	}
@@ -111,10 +108,7 @@ func (c *Controller) Difficulty() int {
 func (c *Controller) Snapshot() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	difficulty := c.baseDifficulty + int(math.Round(c.currentBits))
-	if difficulty > c.maxDifficulty {
-		difficulty = c.maxDifficulty
-	}
+	difficulty := min(c.baseDifficulty+int(math.Round(c.currentBits)), c.maxDifficulty)
 	if difficulty < c.baseDifficulty {
 		difficulty = c.baseDifficulty
 	}

--- a/internal/adaptive/adaptive_test.go
+++ b/internal/adaptive/adaptive_test.go
@@ -91,7 +91,7 @@ func TestControllerRaisesDifficultyUnderAttackThenDecays(t *testing.T) {
 	}
 
 	// Pic d'attaque : beaucoup de requêtes sur la même seconde.
-	for i := 0; i < 2000; i++ {
+	for range 2000 {
 		controller.Observe()
 	}
 	if d := controller.Difficulty(); d <= 16 {

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -368,18 +368,12 @@ func sortVisitors(visitors []VisitorInfo, sortBy string) {
 func paged[T any](items []T, r *http.Request) listResponse[T] {
 	total := len(items)
 	page := queryInt(r, "page", 1)
-	limit := queryInt(r, "limit", 50)
-	if limit > 1000 {
-		limit = 1000
-	}
+	limit := min(queryInt(r, "limit", 50), 1000)
 	start := (page - 1) * limit
 	if start >= total {
 		return listResponse[T]{Items: []T{}, Total: total}
 	}
-	end := start + limit
-	if end > total {
-		end = total
-	}
+	end := min(start+limit, total)
 	return listResponse[T]{Items: items[start:end], Total: total}
 }
 

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gaetandev/waf/internal/jsonstrict"
 	"github.com/gaetandev/waf/internal/storage"
 	"github.com/gaetandev/waf/internal/trust"
 )
@@ -91,9 +92,7 @@ func (s *Server) gdprErase(w http.ResponseWriter, r *http.Request) {
 	var payload struct {
 		IP string `json:"ip"`
 	}
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&payload); err != nil || payload.IP == "" {
+	if err := jsonstrict.Decode(r.Body, &payload); err != nil || payload.IP == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_request", Message: "ip is required"})
 		return
 	}
@@ -184,9 +183,7 @@ func (s *Server) getConfig(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) patchConfig(w http.ResponseWriter, r *http.Request) {
 	var payload map[string]any
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&payload); err != nil {
+	if err := jsonstrict.Decode(r.Body, &payload); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_config_update", Message: "Invalid JSON body"})
 		return
 	}
@@ -243,9 +240,7 @@ func (s *Server) deleteBlacklist(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) addIPEntry(w http.ResponseWriter, r *http.Request, whitelist bool) {
 	var entry IPEntry
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&entry); err != nil {
+	if err := jsonstrict.Decode(r.Body, &entry); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_ip_entry", Message: "Invalid JSON body"})
 		return
 	}

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -67,6 +67,9 @@ func NewServer(cfg config.Config, store storage.Store, scores *trust.ScoreManage
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
+		// Même borne FR-23 que le listener public : l'API admin est censée être
+		// sur loopback, mais la défense en profondeur ne coûte rien ici.
+		MaxHeaderValueCount: cfg.Server.MaxHeaderValueCount,
 	}
 	return server, nil
 }

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -144,25 +144,28 @@ func TestAdminServerEnforcesMaxHeaderValueCount(t *testing.T) {
 	url := fmt.Sprintf("http://%s/waf/admin/blacklist", listener.Addr().String())
 
 	// Sous la limite : la requête atteint le routeur admin.
-	response, err := doWithHeaderLines(t, url, limit/2)
+	status, err := statusWithHeaderLines(t, url, limit/2)
 	if err != nil {
 		t.Fatalf("request under the limit failed: %v", err)
 	}
-	if response.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("status under the limit = %d, want 401", response.StatusCode)
+	if status != http.StatusUnauthorized {
+		t.Fatalf("status under the limit = %d, want 401", status)
 	}
 
 	// Au-dessus : le serveur coupe au parsing, aucune réponse applicative.
-	response, err = doWithHeaderLines(t, url, limit*4)
-	if err == nil && response.StatusCode == http.StatusUnauthorized {
+	status, err = statusWithHeaderLines(t, url, limit*4)
+	if err == nil && status == http.StatusUnauthorized {
 		t.Fatal("request above max_header_value_count reached the handler")
 	}
 }
 
-// doWithHeaderLines envoie une requête portant `count` lignes d'en-tête
+// statusWithHeaderLines envoie une requête portant `count` lignes d'en-tête
 // distinctes (chacune compte pour une valeur, contrairement aux valeurs
-// séparées par des virgules sur une seule ligne).
-func doWithHeaderLines(t *testing.T, url string, count int) (*http.Response, error) {
+// séparées par des virgules sur une seule ligne) et renvoie le code de statut.
+//
+// Le corps est fermé ici : le test ne s'intéresse qu'au statut, et renvoyer la
+// *http.Response obligerait chaque appelant à le fermer.
+func statusWithHeaderLines(t *testing.T, url string, count int) (int, error) {
 	t.Helper()
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -173,10 +176,11 @@ func doWithHeaderLines(t *testing.T, url string, count int) (*http.Response, err
 	}
 	client := &http.Client{Timeout: 5 * time.Second}
 	response, err := client.Do(request)
-	if response != nil {
-		t.Cleanup(func() { _ = response.Body.Close() })
+	if err != nil {
+		return 0, err
 	}
-	return response, err
+	defer func() { _ = response.Body.Close() }()
+	return response.StatusCode, nil
 }
 
 func newTestServer(t *testing.T) *Server {

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -121,7 +123,71 @@ func TestAdminConfigMasksSecrets(t *testing.T) {
 	}
 }
 
+// FR-23 — vérifie que server.max_header_value_count est bien transmis au
+// http.Server (Go 1.27+) et que la requête est rejetée AVANT d'atteindre le
+// handler : une requête sous la limite passe (401, faute de token), une requête
+// au-dessus n'obtient pas de réponse applicative.
+func TestAdminServerEnforcesMaxHeaderValueCount(t *testing.T) {
+	const limit = 20
+
+	server := newTestServerWith(t, func(cfg *config.Config) {
+		cfg.Server.MaxHeaderValueCount = limit
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = server.httpServer.Serve(listener) }()
+
+	url := fmt.Sprintf("http://%s/waf/admin/blacklist", listener.Addr().String())
+
+	// Sous la limite : la requête atteint le routeur admin.
+	response, err := doWithHeaderLines(t, url, limit/2)
+	if err != nil {
+		t.Fatalf("request under the limit failed: %v", err)
+	}
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status under the limit = %d, want 401", response.StatusCode)
+	}
+
+	// Au-dessus : le serveur coupe au parsing, aucune réponse applicative.
+	response, err = doWithHeaderLines(t, url, limit*4)
+	if err == nil && response.StatusCode == http.StatusUnauthorized {
+		t.Fatal("request above max_header_value_count reached the handler")
+	}
+}
+
+// doWithHeaderLines envoie une requête portant `count` lignes d'en-tête
+// distinctes (chacune compte pour une valeur, contrairement aux valeurs
+// séparées par des virgules sur une seule ligne).
+func doWithHeaderLines(t *testing.T, url string, count int) (*http.Response, error) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	for i := range count {
+		request.Header.Add(fmt.Sprintf("X-Filler-%d", i), "x")
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Do(request)
+	if response != nil {
+		t.Cleanup(func() { _ = response.Body.Close() })
+	}
+	return response, err
+}
+
 func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return newTestServerWith(t, nil)
+}
+
+// newTestServerWith construit un serveur admin de test ; customize (optionnel)
+// permet d'ajuster la config AVANT NewServer, donc de tester le câblage
+// config -> http.Server.
+func newTestServerWith(t *testing.T, customize func(*config.Config)) *Server {
 	t.Helper()
 	cfg := config.Default()
 	cfg.Version = "1.0"
@@ -131,6 +197,9 @@ func newTestServer(t *testing.T) *Server {
 	cfg.Challenge.Enabled = false
 	cfg.Admin.Enabled = true
 	cfg.Admin.Token = testAdminToken
+	if customize != nil {
+		customize(&cfg)
+	}
 	store := memory.New(100)
 	t.Cleanup(store.Close)
 	rules, err := access.NewRuleSet(cfg.Whitelist, cfg.Blacklist, cfg.WhitelistUserAgents)

--- a/internal/alert/alert_test.go
+++ b/internal/alert/alert_test.go
@@ -80,21 +80,21 @@ func TestDiscordEmbedIsRich(t *testing.T) {
 }
 
 func TestCooldownDeduplicates(t *testing.T) {
-	var count int32
+	var count atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	n := NewNotifier([]Sink{{Type: SinkGeneric, URL: server.URL}}, time.Hour, 0, server.Client())
 	defer n.Close()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		n.Notify(Event{Trigger: "block", Domain: "example.com", Reason: "blocked"})
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	if c := atomic.LoadInt32(&count); c != 1 {
+	if c := count.Load(); c != 1 {
 		t.Fatalf("delivered %d times, want 1 (cooldown dedup)", c)
 	}
 }
@@ -103,29 +103,29 @@ func TestCooldownDeduplicates(t *testing.T) {
 // transition identique a eu lieu dans le cooldown : sinon une réactivation
 // rapprochée du mode sous attaque (FR-39) passerait silencieuse.
 func TestImmediateBypassesCooldown(t *testing.T) {
-	var count int32
+	var count atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	n := NewNotifier([]Sink{{Type: SinkGeneric, URL: server.URL}}, time.Hour, 0, server.Client())
 	defer n.Close()
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		n.Notify(Event{Trigger: "under_attack_start", Domain: "status.gaetandev.fr", Immediate: true})
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	if c := atomic.LoadInt32(&count); c != 3 {
+	if c := count.Load(); c != 3 {
 		t.Fatalf("delivered %d times, want 3 (les transitions Immediate ignorent le cooldown)", c)
 	}
 }
 
 func TestRetryOnFailureThenSuccess(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if atomic.AddInt32(&attempts, 1) < 2 {
+		if attempts.Add(1) < 2 {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -138,7 +138,7 @@ func TestRetryOnFailureThenSuccess(t *testing.T) {
 	n.Notify(Event{Trigger: "block", Domain: "example.com", Reason: "blocked"})
 	time.Sleep(500 * time.Millisecond)
 
-	if a := atomic.LoadInt32(&attempts); a < 2 {
+	if a := attempts.Load(); a < 2 {
 		t.Fatalf("attempts = %d, want >= 2 (retry)", a)
 	}
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -24,7 +24,7 @@ func TestRecordAndList(t *testing.T) {
 
 func TestFIFORotation(t *testing.T) {
 	trail, _ := NewTrail(3, "")
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		trail.Record("action", "target", "ok")
 	}
 	if got := len(trail.List()); got != 3 {

--- a/internal/behavioral/behavioral_test.go
+++ b/internal/behavioral/behavioral_test.go
@@ -35,7 +35,7 @@ func TestComputeAnomalyDetectsTimeUniformity(t *testing.T) {
 
 func TestComputeAnomalyDetectsPathRepetition(t *testing.T) {
 	paths := make([]string, 0, 15)
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		paths = append(paths, "/same")
 	}
 	// Intervalles irréguliers pour isoler le signal de répétition.
@@ -50,7 +50,7 @@ func TestComputeAnomalyDetectsPathRepetition(t *testing.T) {
 
 func TestComputeAnomalyDetectsHighVelocity(t *testing.T) {
 	paths := make([]string, 0, 25)
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		paths = append(paths, fmt.Sprintf("/p%02d", i))
 	}
 	records := recordsFrom(paths, 100*time.Millisecond) // 25 paths en 2.4s
@@ -88,7 +88,7 @@ func TestHandlerPublishesBehavioralScoreFromPreviousRequests(t *testing.T) {
 	ipHash := trust.HashIP("1.2.3.4")
 	// Pré-remplit le buffer avec un motif uniforme via ingestion synchrone.
 	base := time.Date(2126, 1, 1, 0, 0, 0, 0, time.UTC)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		tracker.ingest(event{ipHash: ipHash, path: fmt.Sprintf("/p%d", i), at: base.Add(time.Duration(i) * time.Second)})
 	}
 	if tracker.Score(ipHash) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -1005,10 +1006,8 @@ func validateFloatRange(fields *[]string, name string, value, min, max float64) 
 }
 
 func validateEnum(fields *[]string, name, value string, allowed ...string) {
-	for _, candidate := range allowed {
-		if value == candidate {
-			return
-		}
+	if slices.Contains(allowed, value) {
+		return
 	}
 	*fields = append(*fields, fmt.Sprintf("%s must be one of %s", name, strings.Join(allowed, ", ")))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,13 +61,17 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Listen                  string    `yaml:"listen"`
-	AdminListen             string    `yaml:"admin_listen"`
-	ReadTimeout             string    `yaml:"read_timeout"`
-	WriteTimeout            string    `yaml:"write_timeout"`
-	IdleTimeout             string    `yaml:"idle_timeout"`
-	GracefulShutdownTimeout string    `yaml:"graceful_shutdown_timeout"`
-	TLS                     ServerTLS `yaml:"tls"`
+	Listen                  string `yaml:"listen"`
+	AdminListen             string `yaml:"admin_listen"`
+	ReadTimeout             string `yaml:"read_timeout"`
+	WriteTimeout            string `yaml:"write_timeout"`
+	IdleTimeout             string `yaml:"idle_timeout"`
+	GracefulShutdownTimeout string `yaml:"graceful_shutdown_timeout"`
+	// MaxHeaderValueCount borne le nombre de valeurs d'en-tête acceptées par
+	// requête (FR-23, http.Server.MaxHeaderValueCount — Go 1.27+). 0 laisse le
+	// défaut Go (http.DefaultMaxHeaderValueCount, 500).
+	MaxHeaderValueCount int       `yaml:"max_header_value_count"`
+	TLS                 ServerTLS `yaml:"tls"`
 }
 
 // ServerTLS configure la terminaison TLS sur le WAF (FR-33, ADR-017). Les
@@ -433,6 +437,7 @@ func Default() Config {
 			WriteTimeout:            "30s",
 			IdleTimeout:             "60s",
 			GracefulShutdownTimeout: "15s",
+			MaxHeaderValueCount:     100,
 			TLS: ServerTLS{
 				Enabled:      false, // opt-in : terminaison TLS par domaine (FR-33)
 				Listen:       ":443",
@@ -677,6 +682,11 @@ func (c *Config) Validate() error {
 	validateDuration(&fields, "challenge.token_ttl", c.Challenge.TokenTTL)
 	validateDuration(&fields, "challenge.cookie_ttl", c.Challenge.CookieTTL)
 
+	// 0 = défaut Go (500). Une borne haute évite qu'une valeur absurde annule de
+	// fait la protection FR-23 ; alignée sur config.schema.json.
+	if c.Server.MaxHeaderValueCount < 0 || c.Server.MaxHeaderValueCount > 10000 {
+		fields = append(fields, "server.max_header_value_count must be between 0 and 10000")
+	}
 	if c.Upstream.MaxIdleConns < 1 {
 		fields = append(fields, "upstream.max_idle_conns must be >= 1")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -290,6 +290,35 @@ func TestValidateUnderAttack(t *testing.T) {
 	}
 }
 
+// FR-23 — borne du nombre de valeurs d'en-tête (http.Server.MaxHeaderValueCount,
+// Go 1.27+). 0 est légal et signifie « défaut Go » (500).
+func TestValidateServerMaxHeaderValueCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{name: "default is valid", value: Default().Server.MaxHeaderValueCount, wantErr: false},
+		{name: "zero means go default", value: 0, wantErr: false},
+		{name: "upper bound accepted", value: 10000, wantErr: false},
+		{name: "negative rejected", value: -1, wantErr: true},
+		{name: "above upper bound rejected", value: 10001, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.Server.MaxHeaderValueCount = tt.value
+			err := cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("Validate() expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Validate() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateServerTLS(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/jsonstrict/jsonstrict.go
+++ b/internal/jsonstrict/jsonstrict.go
@@ -19,8 +19,8 @@
 package jsonstrict
 
 import (
-	json "encoding/json/v2"
 	"encoding/json/jsontext"
+	json "encoding/json/v2"
 	"io"
 )
 

--- a/internal/jsonstrict/jsonstrict.go
+++ b/internal/jsonstrict/jsonstrict.go
@@ -1,0 +1,46 @@
+// Package jsonstrict décode le JSON provenant d'une source non fiable (corps de
+// requête client, réponse d'une API tierce) avec des garde-fous plus stricts que
+// encoding/json v1.
+//
+// Motivation : v1 accepte les noms de membre dupliqués et applique la règle
+// « le dernier gagne ». Un WAF qui lit "b" dans {"k":"a","k":"b"} alors que
+// l'origine lit "a" offre un différentiel de parseur — un vecteur classique de
+// contournement. v1 accepte également l'UTF-8 invalide et le remplace
+// silencieusement par U+FFFD, ce qui altère la valeur inspectée.
+//
+// encoding/json/v2 (Go 1.27) rejette ces deux cas. Les deux options ci-dessous
+// restaurent par ailleurs les comportements v1 sur lesquels le code s'appuie,
+// pour que le seul changement observable soit le rejet de JSON ambigu ou mal
+// formé :
+//
+//   - RejectUnknownMembers      équivalent de Decoder.DisallowUnknownFields
+//   - MatchCaseInsensitiveNames v1 apparie les noms sans tenir compte de la
+//     casse ; v2 exige une correspondance exacte par défaut
+package jsonstrict
+
+import (
+	json "encoding/json/v2"
+	"encoding/json/jsontext"
+	"io"
+)
+
+var opts = json.JoinOptions(
+	json.RejectUnknownMembers(true),
+	json.MatchCaseInsensitiveNames(true),
+)
+
+// Decode lit exactement une valeur JSON depuis r et la décode dans out.
+//
+// Comme json.Decoder.Decode (v1) et contrairement à json.UnmarshalRead, Decode
+// ne lit pas jusqu'à EOF : le contenu qui suit la première valeur est ignoré.
+// C'est ce qui permet de l'utiliser sur un corps de requête non borné sans
+// transformer une requête volumineuse en lecture intégrale.
+func Decode(r io.Reader, out any) error {
+	return json.UnmarshalDecode(jsontext.NewDecoder(r), out, opts)
+}
+
+// Unmarshal décode une valeur JSON déjà en mémoire, avec les mêmes garde-fous
+// que Decode.
+func Unmarshal(data []byte, out any) error {
+	return json.Unmarshal(data, out, opts)
+}

--- a/internal/jsonstrict/jsonstrict_test.go
+++ b/internal/jsonstrict/jsonstrict_test.go
@@ -1,0 +1,94 @@
+package jsonstrict
+
+import (
+	"strings"
+	"testing"
+)
+
+type payload struct {
+	Token string `json:"token"`
+	Nonce string `json:"nonce"`
+}
+
+func TestDecodeRejectsAmbiguousOrMalformedJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+		want    string
+	}{
+		{
+			name: "well formed",
+			body: `{"token":"a","nonce":"n"}`,
+			want: "a",
+		},
+		{
+			// v1 acceptait et retenait "b" : différentiel de parseur si
+			// l'origine, elle, retient "a".
+			name:    "duplicate member name",
+			body:    `{"token":"a","token":"b","nonce":"n"}`,
+			wantErr: true,
+		},
+		{
+			// v1 acceptait et remplaçait par U+FFFD, altérant la valeur inspectée.
+			name:    "invalid utf-8 in string",
+			body:    "{\"token\":\"a\xed\xa0\x80\",\"nonce\":\"n\"}",
+			wantErr: true,
+		},
+		{
+			name:    "unknown member",
+			body:    `{"token":"a","nonce":"n","extra":1}`,
+			wantErr: true,
+		},
+		{
+			// Comportement v1 délibérément préservé : les clients existants qui
+			// varient la casse ne doivent pas casser.
+			name: "case-insensitive member name",
+			body: `{"Token":"a","NONCE":"n"}`,
+			want: "a",
+		},
+		{
+			// Comme Decoder.Decode : on lit une valeur, pas jusqu'à EOF.
+			name: "trailing content after the first value",
+			body: `{"token":"a","nonce":"n"} trailing`,
+			want: "a",
+		},
+		{
+			name:    "not json",
+			body:    `nope`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got payload
+			err := Decode(strings.NewReader(tt.body), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Decode() expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Decode() unexpected error = %v", err)
+			}
+			if got.Token != tt.want {
+				t.Fatalf("token = %q, want %q", got.Token, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalAppliesTheSameGuards(t *testing.T) {
+	var got payload
+	if err := Unmarshal([]byte(`{"token":"a","token":"b"}`), &got); err == nil {
+		t.Fatal("Unmarshal() accepted a duplicate member name")
+	}
+	if err := Unmarshal([]byte(`{"token":"a"}`), &got); err != nil {
+		t.Fatalf("Unmarshal() unexpected error = %v", err)
+	}
+	if got.Token != "a" {
+		t.Fatalf("token = %q, want \"a\"", got.Token)
+	}
+}

--- a/internal/logger/middleware.go
+++ b/internal/logger/middleware.go
@@ -6,13 +6,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/gaetandev/waf/internal/alert"
 	"github.com/gaetandev/waf/internal/gdpr"
 	"github.com/gaetandev/waf/internal/middleware/cloudflare"
 	"github.com/gaetandev/waf/internal/trust"
 	"github.com/gaetandev/waf/internal/upstreamtime"
-	"github.com/google/uuid"
 )
 
 const requestIDHeader = "X-Request-ID"
@@ -21,7 +21,7 @@ type requestIDContextKey struct{}
 
 func (l Logger) Middleware(scores *trust.ScoreManager, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestID := uuid.NewString()
+		requestID := uuid.NewV4().String()
 		startedAt := l.now()
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
 		w.Header().Set(requestIDHeader, requestID)

--- a/internal/logger/middleware_test.go
+++ b/internal/logger/middleware_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/gaetandev/waf/internal/alert"
 	"github.com/gaetandev/waf/internal/config"
 	"github.com/gaetandev/waf/internal/storage/memory"
 	"github.com/gaetandev/waf/internal/trust"
 	"github.com/gaetandev/waf/internal/upstreamtime"
-	"github.com/google/uuid"
 )
 
 type recordingAlerter struct{ calls int }
@@ -50,8 +50,17 @@ func TestMiddlewareWritesSecurityEventJSONWithoutQueryString(t *testing.T) {
 	event := decodeEvent(t, output.String())
 	assertRequiredString(t, event, "timestamp")
 	assertRequiredString(t, event, "request_id")
-	if _, err := uuid.Parse(event["request_id"].(string)); err != nil {
+	parsed, err := uuid.Parse(event["request_id"].(string))
+	if err != nil {
 		t.Fatalf("request_id is not a UUID: %v", err)
+	}
+	// architecture.md documente request_id comme un UUID v4 : on verrouille la
+	// version (nibble haut de l'octet 6) et la variante RFC 9562 (octet 8).
+	if version := parsed[6] >> 4; version != 4 {
+		t.Fatalf("request_id UUID version = %d, want 4", version)
+	}
+	if variant := parsed[8] >> 6; variant != 0b10 {
+		t.Fatalf("request_id UUID variant = %#b, want 0b10 (RFC 9562)", variant)
 	}
 	if event["path"] != "/search" {
 		t.Fatalf("path = %q, want /search", event["path"])

--- a/internal/middleware/antibot/rules.go
+++ b/internal/middleware/antibot/rules.go
@@ -2,6 +2,7 @@ package antibot
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gaetandev/waf/internal/config"
@@ -32,10 +33,8 @@ func NewRules(cfg config.Config) Rules {
 
 func (r Rules) Evaluate(req *http.Request) Decision {
 	path := req.URL.Path
-	for _, honeypotPath := range r.honeypotPaths {
-		if path == honeypotPath {
-			return Decision{Delta: -100, Block: true, Reason: ReasonHoneypot}
-		}
+	if slices.Contains(r.honeypotPaths, path) {
+		return Decision{Delta: -100, Block: true, Reason: ReasonHoneypot}
 	}
 
 	userAgent := req.UserAgent()

--- a/internal/middleware/antiddos/middleware_test.go
+++ b/internal/middleware/antiddos/middleware_test.go
@@ -192,7 +192,7 @@ func TestPressureThrottle429DoesNotFeedBreaker(t *testing.T) {
 	}))
 
 	// Bien au-delà du seuil de violations : le circuit ne doit jamais s'ouvrir.
-	for i := 0; i < DefaultViolationThreshold*3; i++ {
+	for i := range DefaultViolationThreshold * 3 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestFrom("1.2.3.4:1234"))
 		if response.Code != http.StatusTooManyRequests {

--- a/internal/middleware/challenge/conformance_test.go
+++ b/internal/middleware/challenge/conformance_test.go
@@ -250,6 +250,11 @@ func TestConformanceVerifyRejectsMalformedBody(t *testing.T) {
 	}{
 		{name: "invalid json", body: "{not-json"},
 		{name: "unknown field", body: `{"token":"t","nonce":"1","elapsed_ms":1200,"surprise":true}`},
+		// encoding/json v1 acceptait ces deux corps : le membre dupliqué selon la
+		// règle « le dernier gagne » (différentiel de parseur avec l'origine), et
+		// l'UTF-8 invalide en le remplaçant par U+FFFD (valeur inspectée altérée).
+		{name: "duplicate member name", body: `{"token":"a","token":"t","nonce":"1","elapsed_ms":1200}`},
+		{name: "invalid utf-8", body: `{"token":"t` + string([]byte{0xed, 0xa0, 0x80}) + `","nonce":"1","elapsed_ms":1200}`},
 	}
 
 	for _, tt := range tests {

--- a/internal/middleware/challenge/middleware.go
+++ b/internal/middleware/challenge/middleware.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gaetandev/waf/internal/config"
 	browserfp "github.com/gaetandev/waf/internal/fingerprint"
+	"github.com/gaetandev/waf/internal/jsonstrict"
 	"github.com/gaetandev/waf/internal/middleware/cloudflare"
 	"github.com/gaetandev/waf/internal/trust"
 )
@@ -155,9 +156,7 @@ func (m Middleware) verify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var submission Submission
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&submission); err != nil {
+	if err := jsonstrict.Decode(r.Body, &submission); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_submission")
 		return
 	}

--- a/internal/middleware/challenge/middleware_test.go
+++ b/internal/middleware/challenge/middleware_test.go
@@ -344,7 +344,7 @@ func submissionJSONWithRenderer(token string, nonce string, elapsedMS int, rende
 
 func solvePow(t *testing.T, token string, difficultyBits int) string {
 	t.Helper()
-	for nonce := uint64(0); nonce < 10_000_000; nonce++ {
+	for nonce := range uint64(10_000_000) {
 		nonceText := strconv.FormatUint(nonce, 10)
 		sum := sha256.Sum256([]byte(token + nonceText))
 		if hasLeadingZeroBits(sum[:], difficultyBits) {
@@ -361,7 +361,7 @@ func solvePow(t *testing.T, token string, difficultyBits int) string {
 // non déterministe), cela rendait le test "invalid PoW" flaky en CI (~0,4 %).
 func failPow(t *testing.T, token string, difficultyBits int) string {
 	t.Helper()
-	for nonce := uint64(0); nonce < 10_000_000; nonce++ {
+	for nonce := range uint64(10_000_000) {
 		nonceText := strconv.FormatUint(nonce, 10)
 		sum := sha256.Sum256([]byte(token + nonceText))
 		if !hasLeadingZeroBits(sum[:], difficultyBits) {

--- a/internal/middleware/challenge/pow.go
+++ b/internal/middleware/challenge/pow.go
@@ -21,7 +21,7 @@ func hasLeadingZeroBits(hash []byte, difficultyBits int) bool {
 	fullBytes := difficultyBits / 8
 	remainingBits := difficultyBits % 8
 
-	for i := 0; i < fullBytes; i++ {
+	for i := range fullBytes {
 		if hash[i] != 0 {
 			return false
 		}

--- a/internal/middleware/challenge/pow_test.go
+++ b/internal/middleware/challenge/pow_test.go
@@ -44,7 +44,7 @@ func TestHasLeadingZeroBitsSupportsPartialBytes(t *testing.T) {
 func solvePowForTest(t *testing.T, token string, difficultyBits int) (string, string) {
 	t.Helper()
 
-	for nonce := uint64(0); nonce < 10_000_000; nonce++ {
+	for nonce := range uint64(10_000_000) {
 		nonceText := strconv.FormatUint(nonce, 10)
 		hash := sha256.Sum256([]byte(token + nonceText))
 		if hasLeadingZeroBits(hash[:], difficultyBits) {

--- a/internal/middleware/ratelimit/bucket_test.go
+++ b/internal/middleware/ratelimit/bucket_test.go
@@ -9,7 +9,7 @@ func TestTokenBucketAllowsBurst(t *testing.T) {
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	bucket := NewTokenBucket(50, 100, now)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		allowed, _ := bucket.TryConsume(now)
 		if !allowed {
 			t.Fatalf("request %d denied, want allowed", i+1)

--- a/internal/middleware/ratelimit/middleware_test.go
+++ b/internal/middleware/ratelimit/middleware_test.go
@@ -23,7 +23,7 @@ func TestMiddlewareAllowsConfiguredBurstAndThenRateLimits(t *testing.T) {
 
 	handler := middleware.Handler(countingHandler())
 	statuses := make([]int, 0, 150)
-	for i := 0; i < 150; i++ {
+	for range 150 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestFrom("1.2.3.4:1234"))
 		statuses = append(statuses, response.Code)
@@ -156,7 +156,7 @@ func TestMiddlewareSkipsWhitelistedRequests(t *testing.T) {
 	middleware.now = func() time.Time { return now }
 	handler := middleware.Handler(countingHandler())
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		request := requestFrom("10.0.0.1:1234")
 		request.Header.Set("X-WAF-Action", "PASS")
 		response := httptest.NewRecorder()
@@ -180,7 +180,7 @@ func TestPressureThrottlesSustainedRateButKeepsBurst(t *testing.T) {
 	handler := middleware.Handler(countingHandler())
 
 	burstOK := 0
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
 		if response.Code == http.StatusNoContent {
@@ -194,7 +194,7 @@ func TestPressureThrottlesSustainedRateButKeepsBurst(t *testing.T) {
 	// Une seconde plus tard, le refill resserré (5/s) ne rend que 5 jetons.
 	now = now.Add(time.Second)
 	sustainedOK := 0
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("9.9.9.9:1234", pressureCritical))
 		if response.Code == http.StatusNoContent {
@@ -282,7 +282,7 @@ func TestRateLimitPenaltyAppliedOncePerWindow(t *testing.T) {
 	// 1 requête admise puis 15 refusées au même instant (cascade de
 	// sous-requêtes d'un même chargement de page) : UNE seule pénalité.
 	handler.ServeHTTP(httptest.NewRecorder(), requestFrom("9.9.9.9:1234"))
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		handler.ServeHTTP(httptest.NewRecorder(), requestFrom("9.9.9.9:1234"))
 	}
 	visitor, ok := store.GetVisitor(trust.HashIP("9.9.9.9"))
@@ -314,7 +314,7 @@ func TestPressureSparesTrustedVisitor(t *testing.T) {
 	handler := middleware.Handler(countingHandler())
 
 	okCount := 0
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("8.8.8.8:1234", pressureCritical))
 		if response.Code == http.StatusNoContent {
@@ -336,7 +336,7 @@ func TestNormalPressureDoesNotThrottle(t *testing.T) {
 	handler := middleware.Handler(countingHandler())
 
 	okCount := 0
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("7.7.7.7:1234", pressureNormal))
 		if response.Code == http.StatusNoContent {
@@ -358,14 +358,14 @@ func TestPressureThrottleIsReversible(t *testing.T) {
 	handler := middleware.Handler(countingHandler())
 
 	// Épuise le burst nominal sous pression critique.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		handler.ServeHTTP(httptest.NewRecorder(), requestWithPressure("6.6.6.6:1234", pressureCritical))
 	}
 
 	// La pression retombe : le refill repart au débit nominal (20/s) → toute la
 	// rafale suivante passe dès la seconde suivante (au lieu de 5 sous pression).
 	now = now.Add(time.Second)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestWithPressure("6.6.6.6:1234", pressureNormal))
 		if response.Code != http.StatusNoContent {

--- a/internal/risk/assessment_test.go
+++ b/internal/risk/assessment_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -229,10 +230,8 @@ func assertNumberInRange(t *testing.T, value any, schema any) {
 func assertEnumContains(t *testing.T, value any, schema any) {
 	t.Helper()
 
-	for _, allowed := range objectMap(t, schema)["enum"].([]any) {
-		if value == allowed {
-			return
-		}
+	if slices.Contains(objectMap(t, schema)["enum"].([]any), value) {
+		return
 	}
 	t.Fatalf("value %v not allowed by enum %v", value, objectMap(t, schema)["enum"])
 }

--- a/internal/risk/verifybot.go
+++ b/internal/risk/verifybot.go
@@ -2,6 +2,7 @@ package risk
 
 import (
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -167,10 +168,8 @@ func (v *BotVerifier) verifyForwardConfirmed(ip string, bot string) bool {
 		if err != nil {
 			continue
 		}
-		for _, address := range addresses {
-			if address == ip {
-				return true
-			}
+		if slices.Contains(addresses, ip) {
+			return true
 		}
 	}
 	return false

--- a/internal/selfprotect/selfprotect_test.go
+++ b/internal/selfprotect/selfprotect_test.go
@@ -43,7 +43,7 @@ func TestPathGuardLimitsTargetPath(t *testing.T) {
 	}))
 
 	statuses := make([]int, 0, 3)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		req := httptest.NewRequest(http.MethodPost, "http://x/waf/verify", nil)
 		req.RemoteAddr = "1.2.3.4:1234"
 		rr := httptest.NewRecorder()
@@ -64,7 +64,7 @@ func TestPathGuardIgnoresOtherPaths(t *testing.T) {
 	handler := guard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		req := httptest.NewRequest(http.MethodGet, "http://x/other", nil)
 		req.RemoteAddr = "1.2.3.4:1234"
 		rr := httptest.NewRecorder()

--- a/internal/slowloris/slowloris_test.go
+++ b/internal/slowloris/slowloris_test.go
@@ -20,7 +20,7 @@ func TestLimiterReleasesAfterRequest(t *testing.T) {
 	}))
 
 	// Requêtes séquentielles : chacune libère le slot → toutes passent.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, requestFrom("1.2.3.4"))
 		if response.Code != http.StatusNoContent {
@@ -40,11 +40,9 @@ func TestLimiterRejectsConcurrentOverLimit(t *testing.T) {
 	}))
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		handler.ServeHTTP(httptest.NewRecorder(), requestFrom("1.2.3.4"))
-	}()
+	})
 	<-entered // la 1re requête occupe le slot
 
 	// 2e requête concurrente même IP → rejetée (429).

--- a/internal/trust/score_test.go
+++ b/internal/trust/score_test.go
@@ -88,7 +88,7 @@ func TestPenalizeRateLimitOncePerWindow(t *testing.T) {
 		t.Fatalf("Score after first penalty = %d, want 40", visitor.Score)
 	}
 	// Refus supplémentaires dans la même fenêtre : aucune pénalité de plus.
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		if visitor := manager.PenalizeRateLimit("1.2.3.4", "example.test"); visitor.Score != 40 {
 			t.Fatalf("Score within window = %d, want 40 (single penalty per window)", visitor.Score)
 		}

--- a/internal/upstream/pool_test.go
+++ b/internal/upstream/pool_test.go
@@ -7,7 +7,7 @@ func TestRoundRobinCyclesHealthyUpstreams(t *testing.T) {
 		{Address: "a"}, {Address: "b"}, {Address: "c"},
 	})
 	seen := map[string]int{}
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		u, ok := pool.Pick("")
 		if !ok {
 			t.Fatal("expected a healthy upstream")
@@ -24,7 +24,7 @@ func TestRoundRobinCyclesHealthyUpstreams(t *testing.T) {
 func TestUnhealthyUpstreamExcluded(t *testing.T) {
 	pool := NewPool(StrategyRoundRobin, []*Upstream{{Address: "a"}, {Address: "b"}})
 	pool.Upstreams()[0].SetHealthy(false)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		u, ok := pool.Pick("")
 		if !ok || u.Address != "b" {
 			t.Fatalf("pick = %v ok=%v, want only b", u, ok)
@@ -59,7 +59,7 @@ func TestAllDownReturnsFalse(t *testing.T) {
 func TestIPHashIsStable(t *testing.T) {
 	pool := NewPool(StrategyIPHash, []*Upstream{{Address: "a"}, {Address: "b"}, {Address: "c"}})
 	first, _ := pool.Pick("1.2.3.4")
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		u, _ := pool.Pick("1.2.3.4")
 		if u.Address != first.Address {
 			t.Fatalf("ip_hash not stable: %s vs %s", u.Address, first.Address)
@@ -82,7 +82,7 @@ func TestWeightedFavorsHigherWeight(t *testing.T) {
 		{Address: "b", Weight: 1},
 	})
 	seen := map[string]int{}
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		u, _ := pool.Pick("")
 		seen[u.Address]++
 	}

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -29,6 +29,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   de la stdlib (nouveau en Go 1.27). Le contrat « UUID v4 » d'`architecture.md`
   est désormais explicite dans le code (`uuid.NewV4()`) et vérifié par le test
   (version + variante RFC 9562).
+- **FR-30 — parsing JSON durci sur les entrées non fiables** via
+  `encoding/json/v2` (nouveau en Go 1.27), encapsulé dans `internal/jsonstrict` :
+  - un **nom de membre dupliqué** est désormais rejeté (400). v1 appliquait
+    « le dernier gagne » : le WAF lisait `"b"` dans `{"k":"a","k":"b"}` là où une
+    origine appliquant « le premier gagne » lisait `"a"` — différentiel de
+    parseur, vecteur classique de contournement ;
+  - l'**UTF-8 invalide** est rejeté au lieu d'être remplacé par U+FFFD, qui
+    faisait diverger la valeur inspectée de la valeur reçue sur le fil.
+  - Appliqué à `POST /waf/verify` (public, non authentifié) et aux trois
+    endpoints à corps de l'API admin. `MatchCaseInsensitiveNames(true)` conserve
+    l'appariement v1 insensible à la casse et `RejectUnknownMembers(true)`
+    reproduit `DisallowUnknownFields` : le **seul** changement observable est le
+    rejet de JSON ambigu ou mal formé.
+  - **Hors périmètre, délibérément** : les payloads déjà authentifiés par HMAC
+    (cookie, nonce) — produits par le WAF lui-même ; le bus Redis inter-nœuds ;
+    et la réponse AbuseIPDB, qui n'utilise pas `DisallowUnknownFields` et doit
+    tolérer l'ajout de champs par le fournisseur.
 - **Modernisations `go fix`** débloquées par la directive `go 1.27` :
   `min()`, `slices.Contains`, `slices.Backward`, `strings.Cut`, `for range N`.
   Changements mécaniques et sans effet sémantique, isolés dans leur propre commit.

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -18,6 +18,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   version via `go-version-file: go.mod` — aucun changement de workflow requis.
   Docs alignées : `mission.md`, `requirements.md`, conséquences d'ADR-001
   (le corps historique de l'ADR, `accepted`, reste inchangé).
+- **FR-23 — nouvelle borne `server.max_header_value_count`** (défaut **100**,
+  `0` = défaut Go 500) : câblée sur `http.Server.MaxHeaderValueCount`
+  (Go 1.27) pour le listener public, le serveur de challenge ACME, le
+  redirecteur HTTP→HTTPS et l'API admin. Complète `max_connections_per_ip` :
+  cette dernière borne le nombre de requêtes concurrentes, la nouvelle borne le
+  coût de parsing d'**une seule** requête portant des milliers de lignes
+  d'en-tête. Le rejet a lieu dans `net/http`, avant tout middleware.
+- **Dépendance `github.com/google/uuid` supprimée** au profit du paquet `uuid`
+  de la stdlib (nouveau en Go 1.27). Le contrat « UUID v4 » d'`architecture.md`
+  est désormais explicite dans le code (`uuid.NewV4()`) et vérifié par le test
+  (version + variante RFC 9562).
+- **Modernisations `go fix`** débloquées par la directive `go 1.27` :
+  `min()`, `slices.Contains`, `slices.Backward`, `strings.Cut`, `for range N`.
+  Changements mécaniques et sans effet sémantique, isolés dans leur propre commit.
 
 ### Fixed
 

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -6,6 +6,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- **Montée du projet vers Go 1.27** : `go.mod` passe de `go 1.26.0` +
+  `toolchain go1.26.5` à `go 1.27.0`. La directive `go` fait elle-même office de
+  plancher de toolchain : `toolchain go1.26.5` devenait redondant (et donc
+  susceptible de dériver), il est supprimé — go1.27.0 embarque le correctif
+  GO-2026-5856 (fuite ECH dans `crypto/tls`) qui motivait ce pin.
+  Propagation : image de build `golang:1.26-alpine` → `golang:1.27-alpine`
+  (Dockerfile), commentaire golangci-lint du workflow CI. Le CI résout déjà la
+  version via `go-version-file: go.mod` — aucun changement de workflow requis.
+  Docs alignées : `mission.md`, `requirements.md`, conséquences d'ADR-001
+  (le corps historique de l'ADR, `accepted`, reste inchangé).
+
 ### Fixed
 
 - **FR-08/FR-05 (v2.1.0) — cascade de faux positifs sous pression** : pendant un

--- a/specs/decisions/ADR-001-go-language-choice.md
+++ b/specs/decisions/ADR-001-go-language-choice.md
@@ -58,7 +58,7 @@ Les raisons déterminantes :
 
 ## Consequences
 
-- Le projet est développé en Go 1.26+
+- Le projet est développé en Go 1.27+ (plancher initial 1.26+, relevé depuis — voir [changelog.md](../changelog.md))
 - Les dépendances clés : `log/slog` (logging structuré, stdlib — voir ADR-014), `prometheus/client_golang` (métriques), `go-redis/redis` (optionnel), `golang.org/x/crypto` (HMAC/hash)
 - Pas de dépendances à des frameworks web lourds (Gin, Echo) — `net/http` stdlib suffit
 - La spec `specific-go.mdc` du projet s'applique intégralement

--- a/specs/features/js-challenge.feature
+++ b/specs/features/js-challenge.feature
@@ -92,6 +92,22 @@ Feature: Challenge JavaScript
     And la réponse contient {"error": "challenge_too_fast"}
     And le score du visiteur est décrémenté de 20
 
+  Scenario: Corps JSON avec un nom de membre dupliqué — rejeté
+    # Différentiel de parseur : encoding/json v1 appliquait « le dernier gagne »
+    # et lisait "t2", quand une origine appliquant « le premier gagne » aurait lu
+    # "t1". Le WAF refuse désormais d'arbitrer un corps ambigu.
+    Given un visiteur soumet POST /waf/verify avec le corps {"token":"t1","token":"t2","nonce":"1","elapsed_ms":1200}
+    Then le WAF retourne HTTP 400
+    And la réponse contient {"error": "invalid_submission"}
+    And aucun token n'est validé
+
+  Scenario: Corps JSON contenant de l'UTF-8 invalide — rejeté
+    # v1 remplaçait silencieusement les octets invalides par U+FFFD : la valeur
+    # inspectée par le WAF n'était alors plus celle reçue sur le fil.
+    Given un visiteur soumet POST /waf/verify dont le champ "token" contient une séquence UTF-8 invalide
+    Then le WAF retourne HTTP 400
+    And la réponse contient {"error": "invalid_submission"}
+
   Scenario: Challenge trop lent (timeout côté client)
     Given un visiteur soumet POST /waf/verify avec elapsed_ms = 65000
     Then le WAF retourne HTTP 400

--- a/specs/features/slowloris-protection.feature
+++ b/specs/features/slowloris-protection.feature
@@ -61,6 +61,26 @@ Feature: Protection Slowloris & Slow HTTP
     Then le WAF rejette la connexion (TCP RST ou HTTP 429 selon config)
     And un event est journalisé avec reason="too_many_connections_per_ip"
 
+  Scenario: Requête unique portant des milliers de lignes d'en-tête
+    # max_conns_per_ip borne le nombre de requêtes concurrentes ; il ne borne pas
+    # le coût de parsing d'UNE requête. C'est le rôle de max_header_value_count.
+    Given max_header_value_count = 100
+    When une IP envoie une seule requête portant 5 000 lignes d'en-tête distinctes
+    Then le serveur HTTP rejette la requête avant d'exécuter le moindre middleware
+    And la mémoire consommée par le parsing des en-têtes reste bornée
+
+  Scenario: Requête légitime sous la limite d'en-têtes
+    Given max_header_value_count = 100
+    When un navigateur envoie une requête portant ~25 lignes d'en-tête
+    Then la requête est traitée normalement
+
+  Scenario: En-tête unique à valeurs multiples séparées par des virgules
+    # Une ligne "Accept: a, b, c" compte pour 1, pas 3 : la limite vise la
+    # répétition de lignes, pas la richesse d'une valeur.
+    Given max_header_value_count = 100
+    When un client envoie une requête dont un en-tête porte 300 valeurs séparées par des virgules sur une seule ligne
+    Then la requête n'est pas rejetée pour dépassement de max_header_value_count
+
   Scenario: IPs whitelistées exemptées de la limite
     Given l'IP "10.0.0.1" est dans la whitelist
     When elle ouvre 200 connexions simultanées

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -47,7 +47,7 @@ Construire un reverse proxy WAF écrit en Go, hautement performant, qui s'interc
 
 ## Constraints
 
-- Développé en Go 1.26+
+- Développé en Go 1.27+
 - Doit fonctionner derrière Cloudflare (extraction IP réelle via `CF-Connecting-IP`)
 - Binaire unique, pas de dépendances runtime obligatoires (Redis optionnel)
 - Configuration YAML versionnable en Git

--- a/specs/requirements-ops.md
+++ b/specs/requirements-ops.md
@@ -56,6 +56,14 @@ change: "Ajout FR-33 — terminaison TLS par domaine (sélection par SNI), voir 
   - Au-delà → TCP RST ou HTTP 429 selon config
 - Le WAF DOIT détecter les connexions qui consomment le pool sans envoyer de données :
   - Connexions ouvertes > `idle_read_timeout` sans byte reçu → fermer
+- Le WAF DOIT borner le **nombre de valeurs d'en-tête** acceptées par requête :
+  - `max_header_value_count`: configurable (défaut: 100 ; `0` = défaut Go, 500)
+  - Au-delà → la requête est rejetée par le serveur HTTP avant d'atteindre les middlewares
+  - Complète `max_connections_per_ip` : borne le coût d'**une seule** requête portant des
+    milliers de lignes d'en-tête (amplification mémoire/CPU au parsing), là où la limite de
+    connexions borne le nombre de requêtes concurrentes
+  - Les valeurs séparées par des virgules sur une même ligne comptent pour 1 ; les lignes
+    d'en-tête répétées comptent chacune
 - Ces protections DOIVENT fonctionner avant la lecture complète de la requête (niveau net.Conn / http.Server)
 
 ## FR-24 — Bypass des Assets Statiques

--- a/specs/requirements-ops.md
+++ b/specs/requirements-ops.md
@@ -172,6 +172,22 @@ change: "Ajout FR-33 — terminaison TLS par domaine (sélection par SNI), voir 
 - `/waf/metrics` DOIT être protégeable par token (optionnel, désactivé par défaut pour faciliter Prometheus scraping)
 - Sinon, accessible seulement depuis les IPs whitelistées ou le réseau interne
 
+### Parsing JSON des entrées non fiables
+- Tout corps JSON provenant d'un client (`POST /waf/verify`, API admin) DOIT être
+  rejeté (HTTP 400) s'il contient un **nom de membre dupliqué**
+  - Motif : un parseur « le dernier gagne » côté WAF et « le premier gagne » côté
+    origine créent un **différentiel de parseur** — le WAF inspecte une valeur que
+    l'origine ne traitera pas. Le WAF NE DOIT PAS arbitrer un corps ambigu
+- Tout corps JSON client DOIT être rejeté s'il contient de l'**UTF-8 invalide**
+  - Motif : le remplacement silencieux par U+FFFD fait diverger la valeur inspectée
+    de la valeur reçue sur le fil
+- Le WAF DOIT continuer d'appairer les noms de membre **sans tenir compte de la
+  casse** : ce durcissement ne doit pas casser les clients existants
+- Les charges utiles dont l'authenticité est déjà établie par HMAC (cookie de
+  session, nonce) et les réponses d'API tierces sont **hors périmètre** : les
+  premières sont produites par le WAF lui-même, les secondes doivent tolérer
+  l'ajout de champs par le fournisseur
+
 ### Protection globale du WAF
 - Le WAF DOIT détecter les **amplification attacks** sur le challenge : un visiteur qui génère plus de N tokens de challenge sans jamais les soumettre (stocke des nonces en mémoire) → ses nonces sont supprimés et il est challengé plus sévèrement
 - Limite du store de nonces : `challenge.max_pending_nonces` par IP (défaut: 5)

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -139,7 +139,7 @@ change: "FR-08 : le throttle de pression réduit le débit sans rogner le burst,
 - Signal SIGTERM géré pour graceful shutdown (drain des connexions actives)
 
 ### NFR-06 — Compatibilité
-- Go 1.26+
+- Go 1.27+
 - Linux AMD64 et ARM64
 - IPv4 et IPv6 supportés partout
 - TLS 1.2+ supporté côté upstream (vérification cert configurable)

--- a/specs/schemas/config.schema.json
+++ b/specs/schemas/config.schema.json
@@ -47,6 +47,13 @@
           "type": "string",
           "default": "15s"
         },
+        "max_header_value_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000,
+          "default": 100,
+          "description": "FR-23 — nombre maximum de valeurs d'en-tête acceptées par requête (Server.MaxHeaderValueCount, Go 1.27+). Les valeurs séparées par des virgules sur une même ligne comptent pour 1 ; les lignes répétées comptent chacune. 0 = défaut Go (500)."
+        },
         "tls": {
           "type": "object",
           "additionalProperties": false,

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -213,6 +213,12 @@ last-reviewed: 2026-06-03
 | 2026-06-19 | Slice 12.1 FR-39 under-attack | `go test -cover` (touched pkgs) | pass | antiddos 87.3%, challenge 87.1%, config 79.4%, metrics 85.2%, logger 71.0%, alert 82.9% (≥80% on the new business logic) |
 | 2026-06-19 | Slice 12.1 FR-39 under-attack | JSON schema validity (`jq empty`) | pass | config.schema.json + security-event.schema.json valid ; config.example.yaml conforms to schema (jsonschema) |
 | 2026-06-19 | Slice 12.1 FR-39 alert delivery | `go test ./...` | pass | Fix : alertes de transition envoyées en `Immediate` (bypass cooldown). Diagnostic prod (waf-out-10) : attaque en 2 vagues séparées d'un creux >30s → mode activé/levé/réactivé, mais le 2ᵉ `under_attack_start` était avalé par le cooldown 5m du Notifier (même clé trigger+domaine). Test : 3 events Immediate identiques → 3 livrés ; le cooldown dédup normal reste actif pour les autres triggers |
+| 2026-08-26 | Go 1.27 toolchain | `go build ./... && go vet ./... && go test ./...` | pass | `go.mod` → `go 1.27.0` (directive `toolchain` supprimée : redondante, go1.27.0 couvre GO-2026-5856). Dockerfile `golang:1.27-alpine`. CI inchangé (`go-version-file: go.mod`). `go mod tidy` ne bouge ni go.mod ni go.sum |
+| 2026-08-26 | stdlib `uuid` | `go test ./internal/logger/` | pass | Dépendance `github.com/google/uuid` supprimée (paquet `uuid` stdlib, Go 1.27). `uuid.NewV4()` explicite le contrat « UUID v4 » ; le test vérifie désormais version + variante RFC 9562 |
+| 2026-08-26 | FR-23 `max_header_value_count` | `go test ./internal/config/ ./internal/admin/` | pass | `http.Server.MaxHeaderValueCount` (Go 1.27), défaut 100, câblé sur les 4 serveurs HTTP. Test e2e piloté par la config, **vérifié en échec** après retrait du câblage (mutation) |
+| 2026-08-26 | FR-30 JSON strict | `go test ./internal/jsonstrict/ ./internal/middleware/challenge/` | pass | `encoding/json/v2` via `internal/jsonstrict` : noms de membre dupliqués et UTF-8 invalide rejetés sur `/waf/verify` + API admin. Casse insensible et `DisallowUnknownFields` préservés. Conformance étendue (2 cas) |
+| 2026-08-26 | `go fix` modernizers | `go vet ./... && go test ./...` | pass | `min()`, `slices.Contains`, `slices.Backward`, `strings.Cut`, `for range N` — 21 fichiers, mécanique, commit isolé |
+| 2026-08-26 | Race detector | `go test ./... -race` | **non exécuté localement** | `-race` exige CGO ; aucun compilateur C sur le poste Windows. Couvert par le job `test` du CI (ubuntu-latest) |
 
 ### Slice 12.1 — Notes & couverture du périmètre (FR-39)
 


### PR DESCRIPTION
Monte le projet vers Go 1.27 et intègre les apports de cette version qui concernent réellement un WAF. Chaque axe est dans son propre commit, relisible (ou jetable) indépendamment.

## Commits

| Commit | Contenu |
|---|---|
| `chore(go)` | `go.mod` → `go 1.27.0`, `golang:1.27-alpine`, docs |
| `refactor(logger)` | paquet `uuid` de la stdlib, dépendance `github.com/google/uuid` supprimée |
| `feat(server)` | FR-23 — `server.max_header_value_count` |
| `refactor` | modernizers `go fix` débloqués par la directive `go 1.27` |
| `feat(security)` | FR-30 — `encoding/json/v2` sur les entrées non fiables |
| `docs(validation)` | journal des gate checks |

## FR-23 — borne du nombre de valeurs d'en-tête

`max_connections_per_ip` borne le nombre de requêtes concurrentes ; rien ne bornait le coût de parsing d'**une seule** requête portant des milliers de lignes d'en-tête. Nouveau `server.max_header_value_count` (défaut 100, `0` = défaut Go 500) câblé sur `http.Server.MaxHeaderValueCount` pour le listener public, le serveur de challenge ACME, le redirecteur HTTP→HTTPS et l'API admin. Le rejet a lieu dans `net/http`, avant tout middleware.

## FR-30 — rejet du JSON ambigu sur les entrées non fiables

`encoding/json` v1 accepte les noms de membre dupliqués et applique « le dernier gagne ». Un WAF qui lit `"b"` dans `{"k":"a","k":"b"}` alors que l'origine lit `"a"` offre un **différentiel de parseur** — vecteur classique de contournement. v1 accepte aussi l'UTF-8 invalide et le remplace par U+FFFD, faisant diverger la valeur inspectée de celle reçue sur le fil.

`encoding/json/v2` (Go 1.27) rejette les deux, encapsulé dans `internal/jsonstrict` :

| entrée | v1 | après |
|---|---|---|
| membre dupliqué | accepté (`"b"`) | **rejeté** |
| UTF-8 invalide | accepté (→ U+FFFD) | **rejeté** |
| casse variable | accepté | accepté *(préservé)* |
| membre inconnu | rejeté | rejeté |

Deux détails importants :

- `MatchCaseInsensitiveNames(true)` conserve l'appariement v1 insensible à la casse (v2 exige une correspondance exacte par défaut) et `RejectUnknownMembers(true)` reproduit `DisallowUnknownFields` — le **seul** changement observable est le rejet de JSON ambigu ou mal formé.
- Le décodage passe par `UnmarshalDecode` et non `UnmarshalRead` : le second lit jusqu'à EOF, ce qui aurait aggravé l'exposition sur des corps de requête non bornés.

Appliqué à `POST /waf/verify` (public, non authentifié) et aux trois endpoints à corps de l'API admin.

## Écarté délibérément

- **`maphash.ComparableHasher`** ne remplace pas `hash/fnv` dans `internal/upstream/pool.go` : maphash est ensemencé aléatoirement par processus, ce qui casserait le routage collant IP-hash entre redémarrages et entre nœuds.
- **json/v2 sur les payloads signés HMAC** (cookie, nonce — produits par le WAF lui-même), le bus Redis inter-nœuds, et la **réponse AbuseIPDB** : cette dernière n'utilise pas `DisallowUnknownFields` et doit tolérer l'ajout de champs par le fournisseur.
- **`Server.DisableClientPriority`** laissé au défaut : les priorités RFC 9218 ne réordonnent que les flux d'une même connexion cliente, ce n'est pas un vecteur de starvation entre clients.
- **`/debug/pprof/goroutineleak`** (GA en 1.27) non ajouté : nouvel endpoint sur un produit de sécurité, mérite un contrat OpenAPI, un flag de config et une revue de menace dédiés.
- La directive `toolchain` est **supprimée** plutôt que montée à `go1.27.0` : avec `go 1.27.0` elle devient redondante et donc susceptible de dériver. go1.27.0 embarque le correctif GO-2026-5856 qui motivait le pin d'origine.

Gains gratuits, sans code : allocations rapides (~1 %), `compress/flate` plus rapide, unmarshal JSON plus rapide, et le drainage automatique de `Response.Body` en HTTP/1 qui améliore la réutilisation des connexions upstream du reverse proxy.

## Validation

`go build ./...`, `go vet ./...` et `go test ./... -count=1` (40 paquets) passent sous go1.27.0. `go mod tidy` ne modifie ni `go.mod` ni `go.sum`.

Le test e2e de FR-23 a été **vérifié en échec** après retrait du câblage config → `http.Server` : sans cette vérification il ne prouvait rien.

**Non exécuté localement :**

- `go test -race` — exige cgo, aucun compilateur C sur le poste Windows. Couvert par le job `test` du CI (ubuntu-latest).
- `golangci-lint` — non installé localement. Le job `lint` utilise `version: latest`, censé suivre 1.27 ; c'est le point le plus susceptible de casser au premier run CI.

## Spec-first

`config.schema.json`, `requirements-ops.md` (FR-23 + FR-30), `js-challenge.feature`, `slowloris-protection.feature`, `changelog.md` et `validation.md` sont mis à jour. Le corps historique d'ADR-001 (statut `accepted`) est laissé intact — seule sa section *Consequences* est actualisée.

## Hors périmètre, remonté séparément

Les quatre endpoints JSON n'ont aucune borne de taille de corps de requête, alors que `internal/integrity` applique déjà `http.MaxBytesReader`. Préexistant à cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
