### PR TITLE
fix(challenge): apply domains[].challenge_enabled per host (FR-06)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -948,11 +948,17 @@ domains:
 
 Surcharge les paramètres globaux pour un domaine spécifique. Les entrées sont évaluées dans l'ordre ; la première correspondance gagne. Supporte les wildcards (`*.example.com`).
 
+La correspondance d'hôte est insensible à la casse et ignore le port : `Host: API.Example.com:8443` correspond à `api.example.com`. Un wildcard `*.example.com` couvre aussi l'apex `example.com`.
+
+> **Implémenté à ce jour** : `host`, `upstream`, `challenge_enabled`, `tls`.
+> `protected_paths`, `public_paths`, `rate_limit_override` et `trust_override`
+> sont acceptés par le schéma mais **pas encore câblés** — ils n'ont aucun effet.
+
 | Clé | Type | Description |
 |---|---|---|
 | `host` | string | Nom de domaine à matcher (exact ou wildcard `*.`). |
 | `upstream` | string | URL de l'upstream pour ce domaine (surcharge `upstream.address`). |
-| `challenge_enabled` | bool | Active ou désactive le challenge JS pour ce domaine. |
+| `challenge_enabled` | bool | Surcharge `challenge.enabled` pour ce domaine. **Clé absente = hérite du global** (un domaine déclaré pour son seul `upstream` ou son certificat ne perd pas le challenge). `false` = jamais de challenge JS sur ce domaine, **y compris en mode sous attaque** ([FR-39](#antiddosunder_attack--mode--sous-attaque--fr-39-adr-018)). `true` = challenge servi même si `challenge.enabled` est `false` globalement. |
 | `protected_paths` | liste | Préfixes de chemins qui déclenchent **toujours** le challenge, quelle que soit la valeur du score (utile pour `/api/`, `/admin/`). |
 | `public_paths` | liste | Préfixes de chemins qui ne déclenchent **jamais** le challenge (assets, robots.txt, etc.). |
 | `rate_limit_override.requests_per_second` | float | Limite de débit spécifique à ce domaine (remplace la valeur globale). |

--- a/cmd/waf/main.go
+++ b/cmd/waf/main.go
@@ -448,7 +448,10 @@ func routes(cfg config.Config, accessRules *access.RuleSet, securityLogger waflo
 	if cfg.RateLimit.Enabled {
 		proxyHandler = rateLimiter.Handler(proxyHandler)
 	}
-	if cfg.Challenge.Enabled {
+	// FR-06 : monté dès qu'au moins un hôte peut être challengé — soit
+	// challenge.enabled, soit un domains[].challenge_enabled à true. La décision
+	// par requête est prise dans le middleware, qui connaît l'hôte.
+	if challenge.Enabled(cfg) {
 		proxyHandler = challengeMiddleware.Handler(proxyHandler)
 	}
 	proxyHandler = antiDDoS.Handler(proxyHandler)

--- a/cmd/waf/main_test.go
+++ b/cmd/waf/main_test.go
@@ -142,6 +142,51 @@ func TestRoutesAppliesGlobalPressureBeforeChallengeWithout503(t *testing.T) {
 	}
 }
 
+// FR-06 : la chaîne monte le challenge dès qu'un domaine l'active, et la
+// décision par requête suit l'hôte — pas le seul réglage global.
+func TestRoutesAppliesPerDomainChallengeOverride(t *testing.T) {
+	challengeOff, challengeOn := false, true
+	cfg := config.Default()
+	cfg.Cloudflare.Trusted = false
+	cfg.Challenge.Enabled = false // global éteint : seul le domaine l'active
+	cfg.Domains = []config.DomainConfig{
+		{Host: "boxaria.fr", Upstream: "http://10.0.0.1:80", ChallengeEnabled: &challengeOn},
+		{Host: "api.boxaria.fr", Upstream: "http://10.0.0.2:80", ChallengeEnabled: &challengeOff},
+	}
+
+	tests := []struct {
+		host          string
+		wantChallenge bool
+	}{
+		{host: "boxaria.fr", wantChallenge: true},
+		{host: "api.boxaria.fr", wantChallenge: false},
+		{host: "autre.test", wantChallenge: false}, // hôte non listé : global éteint
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			proxied := false
+			handler := routes(cfg, newTestRules(t, nil, nil, nil), newTestLogger(), newTestMetrics(), newTestAntiDDoS(t), newTestRateLimiter(t, cfg), newTestAntiBot(t, cfg), nil, newTestChallenge(t, cfg), newTestScoreManager(t, cfg), nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				proxied = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			request := requestFrom("198.51.100.10:443")
+			request.Host = tt.host
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			served := response.Header().Get("Content-Type") == "text/html; charset=utf-8"
+			if served != tt.wantChallenge {
+				t.Fatalf("challenge served = %v, want %v (status %d)", served, tt.wantChallenge, response.Code)
+			}
+			if proxied == tt.wantChallenge {
+				t.Fatalf("proxied = %v, want %v", proxied, !tt.wantChallenge)
+			}
+		})
+	}
+}
+
 func TestRoutesExposesPrometheusMetricsEndpoint(t *testing.T) {
 	cfg := config.Default()
 	cfg.Cloudflare.Trusted = false

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -332,6 +332,10 @@ honeypot_paths:
   - "/c99.php"
 
 # Configuration par domaine (surcharge les valeurs globales)
+# La clé challenge_enabled est une surcharge à trois états de challenge.enabled :
+#   absente -> le domaine hérite du réglage global (aucune régression par défaut)
+#   false   -> jamais de challenge JS sur ce domaine, même en mode sous attaque
+#   true    -> challenge servi même si challenge.enabled vaut false globalement
 domains:
   - host: "example.com"
     upstream: "http://10.0.0.1:80"
@@ -360,9 +364,9 @@ domains:
     trust_override:
       block_threshold: 20      # Plus agressif sur l'API
 
+  # Pas de clé challenge_enabled : ce domaine hérite de challenge.enabled.
   - host: "*.example.com"
     upstream: "http://10.0.0.3:80"
-    challenge_enabled: true
 
 # Logging
 logging:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -358,9 +358,13 @@ type Challenge struct {
 }
 
 type DomainConfig struct {
-	Host              string             `yaml:"host"`
-	Upstream          string             `yaml:"upstream"`
-	ChallengeEnabled  bool               `yaml:"challenge_enabled"`
+	Host     string `yaml:"host"`
+	Upstream string `yaml:"upstream"`
+	// ChallengeEnabled surcharge Challenge.Enabled pour ce domaine (FR-06). Le
+	// pointeur distingue « clé absente » (nil → hérite du global) de la valeur
+	// explicite false : avec un bool nu, toute entrée domains[] déclarée pour son
+	// seul upstream ou son certificat TLS aurait désactivé le challenge en silence.
+	ChallengeEnabled  *bool              `yaml:"challenge_enabled"`
 	RateLimitOverride *RateLimitOverride `yaml:"rate_limit_override"`
 	TrustOverride     *TrustOverride     `yaml:"trust_override"`
 	ProtectedPaths    []string           `yaml:"protected_paths"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -406,3 +406,44 @@ func TestValidateServerTLS(t *testing.T) {
 		})
 	}
 }
+
+// FR-06 : domains[].challenge_enabled est une surcharge à trois états. Le YAML
+// doit distinguer « clé absente » (nil) de « false explicite ».
+func TestLoadDomainChallengeEnabledTriState(t *testing.T) {
+	t.Setenv(envChallengeSecretKey, testSecret)
+	t.Setenv(envAdminToken, testSecret)
+
+	path := writeConfig(t, `
+version: "1.0"
+server:
+  listen: ":8080"
+upstream:
+  address: "http://example.test"
+domains:
+  - host: "shop.example.com"
+    upstream: "http://10.0.0.1:80"
+  - host: "api.example.com"
+    upstream: "http://10.0.0.2:8000"
+    challenge_enabled: false
+  - host: "boutique.example.com"
+    upstream: "http://10.0.0.3:80"
+    challenge_enabled: true
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Domains) != 3 {
+		t.Fatalf("len(domains) = %d, want 3", len(cfg.Domains))
+	}
+	if cfg.Domains[0].ChallengeEnabled != nil {
+		t.Fatalf("missing challenge_enabled must stay nil, got %v", *cfg.Domains[0].ChallengeEnabled)
+	}
+	if cfg.Domains[1].ChallengeEnabled == nil || *cfg.Domains[1].ChallengeEnabled {
+		t.Fatalf("challenge_enabled: false must decode to an explicit false")
+	}
+	if cfg.Domains[2].ChallengeEnabled == nil || !*cfg.Domains[2].ChallengeEnabled {
+		t.Fatalf("challenge_enabled: true must decode to an explicit true")
+	}
+}

--- a/internal/middleware/challenge/domain.go
+++ b/internal/middleware/challenge/domain.go
@@ -1,0 +1,98 @@
+package challenge
+
+import (
+	"net"
+	"strings"
+
+	"github.com/gaetandev/waf/internal/config"
+)
+
+// domainGate résout, pour l'hôte d'une requête, si le challenge JS doit être
+// servi (FR-06). `domains[].challenge_enabled` est une surcharge à trois états
+// de `challenge.enabled` :
+//
+//	nil   -> le domaine hérite du réglage global
+//	false -> jamais de challenge sur ce domaine, y compris sous le mode « sous
+//	         attaque » (FR-39) : c'est une décision explicite de l'opérateur
+//	         (typiquement une API dont les clients ne peuvent pas exécuter de JS),
+//	         elle prime sur l'escalade automatique
+//	true  -> challenge servi même si `challenge.enabled` vaut false globalement
+//
+// La correspondance d'hôte suit les règles du routage `domains[]` : casse
+// ignorée, port retiré, exacte ou wildcard `*.example.com` (qui couvre aussi
+// l'apex `example.com`), première entrée correspondante gagnante.
+type domainGate struct {
+	global    bool
+	overrides []domainOverride
+}
+
+type domainOverride struct {
+	host     string // hôte normalisé, wildcard sans le préfixe "*."
+	wildcard bool
+	enabled  bool
+}
+
+func newDomainGate(cfg config.Config) domainGate {
+	gate := domainGate{global: cfg.Challenge.Enabled}
+	for _, domain := range cfg.Domains {
+		if domain.ChallengeEnabled == nil {
+			continue // clé absente : le domaine hérite du global
+		}
+		host := normalizeHost(domain.Host)
+		wildcard := strings.HasPrefix(host, "*.")
+		gate.overrides = append(gate.overrides, domainOverride{
+			host:     strings.TrimPrefix(host, "*."),
+			wildcard: wildcard,
+			enabled:  *domain.ChallengeEnabled,
+		})
+	}
+	return gate
+}
+
+func (g domainGate) enabledFor(host string) bool {
+	requestHost := normalizeHost(host)
+	for _, override := range g.overrides {
+		if override.matches(requestHost) {
+			return override.enabled
+		}
+	}
+	return g.global
+}
+
+// anyEnabled indique si au moins un hôte peut recevoir un challenge : le global
+// est actif, ou un domaine l'active explicitement alors que le global est éteint.
+func (g domainGate) anyEnabled() bool {
+	if g.global {
+		return true
+	}
+	for _, override := range g.overrides {
+		if override.enabled {
+			return true
+		}
+	}
+	return false
+}
+
+func (o domainOverride) matches(host string) bool {
+	if o.wildcard {
+		return host == o.host || strings.HasSuffix(host, "."+o.host)
+	}
+	return host == o.host
+}
+
+// normalizeHost met l'hôte en minuscules et retire le port éventuel. Un Host
+// IPv6 littéral ("[::1]:8443") est géré par net.SplitHostPort.
+func normalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return hostname
+	}
+	return host
+}
+
+// Enabled indique si le middleware de challenge doit être monté dans la chaîne :
+// soit `challenge.enabled` est vrai, soit au moins un `domains[]` l'active
+// explicitement alors que le global est éteint (FR-06).
+func Enabled(cfg config.Config) bool {
+	return newDomainGate(cfg).anyEnabled()
+}

--- a/internal/middleware/challenge/domain_test.go
+++ b/internal/middleware/challenge/domain_test.go
@@ -1,0 +1,277 @@
+package challenge
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gaetandev/waf/internal/config"
+	"github.com/gaetandev/waf/internal/storage/memory"
+	"github.com/gaetandev/waf/internal/trust"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// FR-06 : domains[].challenge_enabled surcharge challenge.enabled par domaine.
+func TestDomainGateResolvesOverridePerHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		global  bool
+		domains []config.DomainConfig
+		host    string
+		want    bool
+	}{
+		{
+			name:   "aucun domaine configuré — global appliqué",
+			global: true,
+			host:   "example.test",
+			want:   true,
+		},
+		{
+			name:    "clé absente — le domaine hérite du global",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "shop.example.com"}},
+			host:    "shop.example.com",
+			want:    true,
+		},
+		{
+			name:    "clé absente — hérite aussi d'un global désactivé",
+			global:  false,
+			domains: []config.DomainConfig{{Host: "shop.example.com"}},
+			host:    "shop.example.com",
+			want:    false,
+		},
+		{
+			name:    "false explicite — challenge désactivé pour ce domaine",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "api.example.com", ChallengeEnabled: boolPtr(false)}},
+			host:    "api.example.com",
+			want:    false,
+		},
+		{
+			name:    "true explicite — challenge forcé malgré un global désactivé",
+			global:  false,
+			domains: []config.DomainConfig{{Host: "boutique.example.com", ChallengeEnabled: boolPtr(true)}},
+			host:    "boutique.example.com",
+			want:    true,
+		},
+		{
+			name:    "hôte non listé — global appliqué",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "api.example.com", ChallengeEnabled: boolPtr(false)}},
+			host:    "autre.test",
+			want:    true,
+		},
+		{
+			name:    "casse et port ignorés",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "API.Example.com", ChallengeEnabled: boolPtr(false)}},
+			host:    "api.EXAMPLE.com:8443",
+			want:    false,
+		},
+		{
+			name:    "wildcard — sous-domaine couvert",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "*.example.com", ChallengeEnabled: boolPtr(false)}},
+			host:    "api.example.com",
+			want:    false,
+		},
+		{
+			name:    "wildcard — apex couvert",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "*.example.com", ChallengeEnabled: boolPtr(false)}},
+			host:    "example.com",
+			want:    false,
+		},
+		{
+			name:   "première correspondance gagne",
+			global: true,
+			domains: []config.DomainConfig{
+				{Host: "api.example.com", ChallengeEnabled: boolPtr(true)},
+				{Host: "*.example.com", ChallengeEnabled: boolPtr(false)},
+			},
+			host: "api.example.com",
+			want: true,
+		},
+		{
+			name:    "hôte IPv6 littéral avec port",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "::1", ChallengeEnabled: boolPtr(false)}},
+			host:    "[::1]:8443",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Challenge.Enabled = tt.global
+			cfg.Domains = tt.domains
+			if got := newDomainGate(cfg).enabledFor(tt.host); got != tt.want {
+				t.Fatalf("enabledFor(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+// Enabled décide du montage du middleware dans la chaîne : un domaine qui active
+// explicitement le challenge doit le faire monter même si le global est éteint.
+func TestEnabledDecidesMounting(t *testing.T) {
+	tests := []struct {
+		name    string
+		global  bool
+		domains []config.DomainConfig
+		want    bool
+	}{
+		{name: "global activé", global: true, want: true},
+		{name: "global désactivé, aucun domaine", global: false, want: false},
+		{
+			name:    "global désactivé, domaine à true",
+			global:  false,
+			domains: []config.DomainConfig{{Host: "boutique.example.com", ChallengeEnabled: boolPtr(true)}},
+			want:    true,
+		},
+		{
+			name:    "global désactivé, domaine à false",
+			global:  false,
+			domains: []config.DomainConfig{{Host: "api.example.com", ChallengeEnabled: boolPtr(false)}},
+			want:    false,
+		},
+		{
+			name:    "global activé, tous les domaines à false — reste monté pour les hôtes non listés",
+			global:  true,
+			domains: []config.DomainConfig{{Host: "api.example.com", ChallengeEnabled: boolPtr(false)}},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Challenge.Enabled = tt.global
+			cfg.Domains = tt.domains
+			if got := Enabled(cfg); got != tt.want {
+				t.Fatalf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMiddlewareSkipsChallengeOnDisabledDomain(t *testing.T) {
+	middleware := newTestChallengeMiddlewareWithDomains(t, true, []config.DomainConfig{
+		{Host: "api.example.com", ChallengeEnabled: boolPtr(false)},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "http://api.example.com/page", nil)
+	request.RemoteAddr = "3.3.3.3:1234"
+	request.Header.Set("Accept", "text/html")
+	response := httptest.NewRecorder()
+
+	called := false
+	middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(response, request)
+
+	if !called {
+		t.Fatal("next handler should be called on a domain with challenge_enabled=false")
+	}
+	if strings.Contains(response.Body.String(), "Protected by GaetanDev.fr") {
+		t.Fatal("challenge page served on a domain with challenge_enabled=false")
+	}
+}
+
+// Un domaine listé sans la clé challenge_enabled (typiquement pour son seul
+// upstream ou son certificat TLS) ne doit pas perdre le challenge : c'est le
+// fail-open silencieux qu'évite le *bool.
+func TestMiddlewareChallengesDomainWithoutOverride(t *testing.T) {
+	middleware := newTestChallengeMiddlewareWithDomains(t, true, []config.DomainConfig{
+		{Host: "shop.example.com", Upstream: "http://10.0.0.1:80"},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "http://shop.example.com/page", nil)
+	request.RemoteAddr = "3.3.3.3:1234"
+	request.Header.Set("Accept", "text/html")
+	response := httptest.NewRecorder()
+
+	middleware.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not be called")
+	})).ServeHTTP(response, request)
+
+	if !strings.Contains(response.Body.String(), "Protected by GaetanDev.fr") {
+		t.Fatal("domain without the challenge_enabled key must inherit the global setting")
+	}
+}
+
+// challenge_enabled=false est une décision explicite de l'opérateur : elle prime
+// sur l'escalade automatique du mode « sous attaque » (FR-39).
+func TestMiddlewareDisabledDomainWinsOverUnderAttack(t *testing.T) {
+	middleware := newTestChallengeMiddlewareWithDomains(t, true, []config.DomainConfig{
+		{Host: "api.example.com", ChallengeEnabled: boolPtr(false)},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "http://api.example.com/page", nil)
+	request.RemoteAddr = "3.3.3.3:1234"
+	request.Header.Set("Accept", "text/html")
+	request.Header.Set("X-WAF-Under-Attack-Enforce", "true")
+	response := httptest.NewRecorder()
+
+	called := false
+	middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(response, request)
+
+	if !called {
+		t.Fatal("under-attack mode must not override an explicit challenge_enabled=false")
+	}
+}
+
+// "/waf/" est un préfixe réservé au WAF sur tous les domaines : /waf/verify n'est
+// jamais transmis à l'upstream, même là où le challenge est désactivé.
+func TestMiddlewareServesVerifyOnDisabledDomain(t *testing.T) {
+	middleware := newTestChallengeMiddlewareWithDomains(t, true, []config.DomainConfig{
+		{Host: "api.example.com", ChallengeEnabled: boolPtr(false)},
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "http://api.example.com/waf/verify", strings.NewReader(`{"token":"","nonce":""}`))
+	request.RemoteAddr = "3.3.3.3:1234"
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	middleware.Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("/waf/verify must not be forwarded upstream")
+	})).ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "invalid_submission") {
+		t.Fatalf("body = %q, want invalid_submission", response.Body.String())
+	}
+}
+
+func newTestChallengeMiddlewareWithDomains(t *testing.T, global bool, domains []config.DomainConfig) Middleware {
+	t.Helper()
+	cfg := config.Default()
+	cfg.Version = "1.0"
+	cfg.Server.Listen = ":0"
+	cfg.Upstream.Address = "http://example.test"
+	cfg.Challenge.SecretKey = testKey
+	cfg.Challenge.PowDifficulty = 8
+	cfg.Challenge.Enabled = global
+	cfg.Domains = domains
+	cfg.Admin.Enabled = false
+	manager, err := trust.NewScoreManager(memory.New(100), cfg)
+	if err != nil {
+		t.Fatalf("NewScoreManager() error = %v", err)
+	}
+	pageTemplate := template.Must(template.New("challenge").Parse(`Protected by GaetanDev.fr {{.Token}}`))
+	middleware, err := NewMiddlewareFromTemplate(cfg, manager, pageTemplate)
+	if err != nil {
+		t.Fatalf("NewMiddlewareFromTemplate() error = %v", err)
+	}
+	return middleware
+}

--- a/internal/middleware/challenge/middleware.go
+++ b/internal/middleware/challenge/middleware.go
@@ -24,6 +24,7 @@ type Middleware struct {
 	cookieIssuer CookieIssuer
 	scores       *trust.ScoreManager
 	template     *template.Template
+	domains      domainGate
 	cookieTTL    time.Duration
 	difficulty   int
 	difficultyFn func() int
@@ -94,6 +95,7 @@ func NewMiddleware(cfg config.Config, scores *trust.ScoreManager, templatePath s
 		cookieIssuer: NewCookieIssuer(cfg.Challenge.CookieName, cfg.Challenge.SecretKey),
 		scores:       scores,
 		template:     pageTemplate,
+		domains:      newDomainGate(cfg),
 		cookieTTL:    cookieTTL,
 		difficulty:   cfg.Challenge.PowDifficulty,
 		minElapsedMS: cfg.Challenge.MinElapsedMS,
@@ -115,6 +117,7 @@ func NewMiddlewareFromTemplate(cfg config.Config, scores *trust.ScoreManager, pa
 		cookieIssuer: NewCookieIssuer(cfg.Challenge.CookieName, cfg.Challenge.SecretKey),
 		scores:       scores,
 		template:     pageTemplate,
+		domains:      newDomainGate(cfg),
 		cookieTTL:    cookieTTL,
 		difficulty:   cfg.Challenge.PowDifficulty,
 		minElapsedMS: cfg.Challenge.MinElapsedMS,
@@ -126,6 +129,13 @@ func (m Middleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == verifyPath {
 			m.verify(w, r)
+			return
+		}
+		// Surcharge par domaine (FR-06) : évaluée avant toute autre décision, y
+		// compris le mode « sous attaque ». /waf/verify reste servi au-dessus :
+		// "/waf/" est un préfixe réservé au WAF sur tous les domaines.
+		if !m.domains.enabledFor(r.Host) {
+			next.ServeHTTP(w, r)
 			return
 		}
 		if r.Header.Get("X-WAF-Action") == "PASS" {

--- a/specs/changelog.md
+++ b/specs/changelog.md
@@ -52,6 +52,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **FR-06 — `domains[].challenge_enabled` n'avait aucun effet** : la clé était
+  documentée (CONFIG.md, `config.schema.json`) et désérialisée dans
+  `config.DomainConfig`, mais **jamais lue**. Le challenge JS était monté et servi
+  uniquement selon le `challenge.enabled` global : un domaine déclarant
+  `challenge_enabled: false` recevait quand même la page de challenge, et un
+  domaine déclarant `challenge_enabled: true` restait sans challenge si le global
+  était à `false`.
+  Le champ devient un **`*bool` à trois états** — absent = hérite du global,
+  `false` = jamais de challenge sur ce domaine (y compris sous le mode « sous
+  attaque » FR-39, décision explicite de l'opérateur qui prime sur l'escalade
+  automatique), `true` = force le challenge même si le global est à `false`.
+  Le `*bool` est indispensable : avec un `bool`, le zéro-valeur aurait désactivé
+  le challenge sur toute entrée `domains[]` déclarée pour son seul `upstream` ou
+  son certificat TLS — un fail-open silencieux.
+  La résolution d'hôte réutilise les règles de routage `domains[]` (casse ignorée,
+  port retiré, wildcard `*.example.com` couvrant l'apex, première correspondance
+  gagnante). Le middleware est désormais monté dès qu'**au moins un** domaine
+  active le challenge, même quand `challenge.enabled` est `false`.
+  `POST /waf/verify` reste servi par le WAF sur tous les domaines : `/waf/` est un
+  préfixe réservé, et un token est de toute façon lié à l'hôte émetteur.
 - **FR-08/FR-05 (v2.1.0) — cascade de faux positifs sous pression** : pendant un
   DDoS, un visiteur légitime était tué en un clic. Le throttle de pression
   divisait aussi la **capacité de burst** (÷4 en critical) : un chargement de

--- a/specs/features/js-challenge.feature
+++ b/specs/features/js-challenge.feature
@@ -44,6 +44,54 @@ Feature: Challenge JavaScript
     And la requête est transmise (couverte par rate-limit + moteur de risque)
     # fetch/axios/mobile ne peuvent pas exécuter le JS : les challenger les casse.
 
+  Scenario: Domaine avec challenge_enabled = false — aucun challenge servi
+    Given le WAF est configuré avec challenge.enabled = true
+    And le domaine "api.example.com" est configuré avec challenge_enabled = false
+    And un visiteur sans cookie sous le seuil de confiance
+    When il envoie une requête GET "https://api.example.com/page" avec Accept "text/html"
+    Then le WAF ne sert PAS la page de challenge
+    And la requête est transmise à l'upstream
+    # Le domaine reste couvert par blacklist, rate-limit, anti-bot et moteur de risque.
+
+  Scenario: Domaine sans clé challenge_enabled — hérite du global
+    Given le WAF est configuré avec challenge.enabled = true
+    And le domaine "shop.example.com" est configuré sans clé challenge_enabled
+    And un visiteur sans cookie sous le seuil de confiance
+    When il envoie une requête GET "https://shop.example.com/page" avec Accept "text/html"
+    Then le WAF sert la page de challenge
+    # Une entrée domains[] déclarée pour son seul upstream (ou son certificat TLS)
+    # ne doit pas désactiver le challenge par effet de bord du zéro-valeur booléen.
+
+  Scenario: Domaine avec challenge_enabled = true et challenge global désactivé
+    Given le WAF est configuré avec challenge.enabled = false
+    And le domaine "boutique.example.com" est configuré avec challenge_enabled = true
+    And un visiteur sans cookie sous le seuil de confiance
+    When il envoie une requête GET "https://boutique.example.com/page" avec Accept "text/html"
+    Then le WAF sert la page de challenge
+
+  Scenario: Correspondance d'hôte — casse, port et wildcard
+    Given le domaine "*.example.com" est configuré avec challenge_enabled = false
+    And un visiteur sans cookie sous le seuil de confiance
+    When il envoie une requête GET avec l'en-tête Host "API.Example.com:8443" et Accept "text/html"
+    Then le WAF ne sert PAS la page de challenge
+    # Correspondance insensible à la casse, port ignoré ; "*.example.com" couvre
+    # aussi l'apex "example.com". Première entrée domains[] correspondante gagne.
+
+  Scenario: Mode sous attaque — challenge_enabled = false reste respecté
+    Given le mode « sous attaque » (FR-39) est actif sur le domaine "api.example.com"
+    And le domaine "api.example.com" est configuré avec challenge_enabled = false
+    When un visiteur sans cookie envoie une requête GET "/page" avec Accept "text/html"
+    Then le WAF ne sert PAS la page de challenge
+    # challenge_enabled = false est une décision explicite de l'opérateur : elle
+    # prime sur l'escalade automatique, qui casserait des clients incapables de JS.
+
+  Scenario: POST /waf/verify reste servi sur un domaine sans challenge
+    Given le domaine "api.example.com" est configuré avec challenge_enabled = false
+    When un client envoie POST "https://api.example.com/waf/verify" avec un corps invalide
+    Then le WAF retourne HTTP 400 avec {"error": "invalid_submission"}
+    And la requête n'est PAS transmise à l'upstream
+    # "/waf/" est un préfixe réservé au WAF sur tous les domaines.
+
   Scenario: Challenge JS réussi — cookie émis et redirect
     Given un visiteur a reçu la page de challenge avec un token valide
     When le JavaScript exécute le proof-of-work (elapsed_ms = 1200)

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -1,9 +1,9 @@
 ---
 status: approved
-version: 2.1.0
-last-reviewed: 2026-07-18
+version: 2.2.0
+last-reviewed: 2026-08-31
 reviewed-by: GaetanDev
-change: "FR-08 : le throttle de pression réduit le débit sans rogner le burst, et ses 429 ne nourrissent ni le circuit breaker ni la pénalité de score ; FR-05 : pénalité rate-limit au plus une fois par fenêtre (anti-cascade sous-requêtes)"
+change: "FR-06 : `domains[].challenge_enabled` devient une surcharge à trois états (absent = hérite du global, false = jamais de challenge même sous attaque, true = force le challenge)"
 ---
 
 # Requirements — WAF Anti-DDoS / Anti-Bot
@@ -65,6 +65,12 @@ change: "FR-08 : le throttle de pression réduit le débit sans rogner le burst,
 - Le WAF DOIT rejeter les challenges soumis après expiration (TTL: 30 s)
 - Le WAF NE DOIT servir le challenge JS que pour une **navigation de navigateur** (méthode `GET`/`HEAD` avec `Accept` contenant `text/html`). Les appels API/XHR (`fetch`, `axios`, clients mobiles…) ne peuvent pas exécuter le JS : ils contournent le challenge (et restent couverts par le rate-limit, le moteur de risque, etc.) au lieu d'être cassés par une page HTML
 - La page de challenge et les réponses de `/waf/verify` (succès comme erreur) DOIVENT être non-cacheables (`Cache-Control: no-store`, `Pragma: no-cache`, `Expires: 0`) : le token est court et lié à l'IP, un cache CDN figerait un token expiré pour tous les visiteurs → boucle de challenge infinie
+- Le challenge JS DOIT être activable/désactivable **par domaine** via `domains[].challenge_enabled`, qui surcharge le `challenge.enabled` global :
+  - clé **absente** → le domaine hérite de `challenge.enabled` (défaut : activé). Un domaine listé uniquement pour son `upstream` ou son certificat NE DOIT PAS perdre le challenge par effet de bord
+  - `false` → aucune page de challenge n'est servie sur ce domaine, **y compris en mode « sous attaque » (FR-39)** : c'est une déclaration explicite de l'opérateur (typiquement une API dont les clients ne peuvent pas exécuter de JS). Le domaine reste couvert par le reste de la chaîne (blacklist, rate-limit, anti-bot, moteur de risque)
+  - `true` → le challenge est servi sur ce domaine même si `challenge.enabled` est `false` globalement
+  - La correspondance d'hôte DOIT suivre les mêmes règles que le routage `domains[]` : insensible à la casse, port ignoré, correspondance exacte ou wildcard `*.example.com` (qui couvre aussi l'apex `example.com`), **première entrée correspondante gagne**
+  - `POST /waf/verify` reste servi par le WAF sur tous les domaines (chemin réservé `/waf/`), quel que soit `challenge_enabled` : un token est lié à l'hôte qui l'a émis
 
 ### FR-07 — Anti-Bot
 - Le WAF DOIT analyser les headers HTTP pour détecter les bots (User-Agent vide, bot connus, headless browsers)

--- a/specs/schemas/config.schema.json
+++ b/specs/schemas/config.schema.json
@@ -793,6 +793,7 @@
         },
         "challenge_enabled": {
           "type": "boolean",
+          "description": "Surcharge de challenge.enabled pour ce domaine. Clé absente = hérite du global. false = jamais de challenge JS sur ce domaine, y compris en mode sous attaque (FR-39). true = challenge servi même si challenge.enabled est false.",
           "default": true
         },
         "rate_limit_override": {

--- a/specs/tasks.md
+++ b/specs/tasks.md
@@ -615,3 +615,19 @@ last-updated: 2026-06-09
 - **Validation 2026-06-19** : `go test ./...`, `go vet ./...`, `go build ./...`, `gofmt -l`, `go test -race` (antiddos/challenge) passent ; couverture antiddos 87.3% / challenge 87.1% ; schemas JSON valides ; config.example.yaml conforme. Detail dans validation.md.
 - **Statut** : implemente.
 - **Spec** : requirements-detection.md FR-39 ; features/anti-ddos.feature ; ADR-018 ; schemas/config.schema.json ; schemas/security-event.schema.json
+
+## Sprint 13 - Correctifs de conformite config (Phase 13)
+
+### T13.1 - `domains[].challenge_enabled` sans effet (FR-06)
+- [x] Constat : la cle etait documentee (CONFIG.md, `config.schema.json`) et deserialisee dans `config.DomainConfig`, mais **jamais lue** — le challenge JS ne suivait que le `challenge.enabled` global
+- [x] Passer `DomainConfig.ChallengeEnabled` de `bool` a `*bool` : distinguer « cle absente » (herite du global) de « false explicite ». Avec un `bool` nu, le zero-valeur desactivait le challenge sur toute entree `domains[]` declaree pour son seul upstream ou son certificat TLS (fail-open silencieux)
+- [x] `internal/middleware/challenge/domain.go` : `domainGate` resout la decision par hote avec les regles de routage `domains[]` (casse ignoree, port retire, wildcard `*.example.com` couvrant l'apex, premiere correspondance gagnante)
+- [x] Cabler le gate dans `Middleware.Handler`, **avant** la lecture de `X-WAF-Under-Attack-Enforce` : un `false` explicite prime sur l'escalade automatique FR-39, qui casserait des clients incapables d'executer du JS
+- [x] `POST /waf/verify` reste servi sur tous les domaines (prefixe `/waf/` reserve, token lie a l'hote emetteur)
+- [x] `challenge.Enabled(cfg)` remplace `cfg.Challenge.Enabled` comme condition de montage dans `cmd/waf/main.go` : la chaine monte le middleware des qu'au moins un domaine active le challenge
+- [x] Tests : table du gate (11 cas : heritage, false/true explicites, hote non liste, casse+port, wildcard sous-domaine et apex, premiere correspondance, IPv6), montage (`Enabled`), 4 cas middleware (domaine desactive, domaine sans cle, sous-attaque, `/waf/verify`), tri-etat YAML, e2e `routes()`. Gate et condition de montage **verifies en echec** par mutation
+- [ ] `protected_paths`, `public_paths`, `rate_limit_override`, `trust_override` — **toujours non cables**, hors perimetre ; documente comme tel dans CONFIG.md
+- **Acceptance** : `challenge_enabled: false` sur un domaine supprime toute page de challenge sur cet hote (y compris sous attaque) ; `true` la sert meme avec `challenge.enabled: false` global ; une entree `domains[]` sans la cle conserve le comportement global.
+- **Validation 2026-08-31** : `go build ./...`, `go vet ./...`, `go test ./...` (413 tests, 41 paquets), `gofmt -l` passent ; schema JSON valide ; `config.example.yaml` conforme. Detail dans validation.md.
+- **Statut** : implemente.
+- **Spec** : requirements.md FR-06 (v2.2.0) ; features/js-challenge.feature ; schemas/config.schema.json

--- a/specs/validation.md
+++ b/specs/validation.md
@@ -219,6 +219,10 @@ last-reviewed: 2026-06-03
 | 2026-08-26 | FR-30 JSON strict | `go test ./internal/jsonstrict/ ./internal/middleware/challenge/` | pass | `encoding/json/v2` via `internal/jsonstrict` : noms de membre dupliqués et UTF-8 invalide rejetés sur `/waf/verify` + API admin. Casse insensible et `DisallowUnknownFields` préservés. Conformance étendue (2 cas) |
 | 2026-08-26 | `go fix` modernizers | `go vet ./... && go test ./...` | pass | `min()`, `slices.Contains`, `slices.Backward`, `strings.Cut`, `for range N` — 21 fichiers, mécanique, commit isolé |
 | 2026-08-26 | Race detector | `go test ./... -race` | **non exécuté localement** | `-race` exige CGO ; aucun compilateur C sur le poste Windows. Couvert par le job `test` du CI (ubuntu-latest) |
+| 2026-08-31 | FR-06 `domains[].challenge_enabled` | `go build ./... && go vet ./... && go test ./...` | pass | 413 tests, 41 paquets. Champ passé en `*bool` (trois états) ; gate par hôte dans `internal/middleware/challenge/domain.go` ; montage de la chaîne via `challenge.Enabled(cfg)` |
+| 2026-08-31 | FR-06 mutation check | `go test ./cmd/waf/ -run TestRoutesAppliesPerDomainChallengeOverride` | pass | **Vérifié en échec** : condition de montage remise à `cfg.Challenge.Enabled` → `boxaria.fr` ne reçoit plus le challenge (204 au lieu de la page) |
+| 2026-08-31 | FR-06 mutation check | `go test ./internal/middleware/challenge/` | pass | **Vérifié en échec** : gate `enabledFor` neutralisé → `TestMiddlewareSkipsChallengeOnDisabledDomain` et `TestMiddlewareDisabledDomainWinsOverUnderAttack` échouent |
+| 2026-08-31 | FR-06 lint | `golangci-lint run ./...` | **non exécuté localement** | Binaire absent du poste ; couvert par le job `lint` du CI |
 
 ### Slice 12.1 — Notes & couverture du périmètre (FR-39)
 
@@ -227,6 +231,12 @@ last-reviewed: 2026-06-03
 - **Réglage requis** : le déclenchement dépend de `global_requests_per_second`. Sur petite infra, l'abaisser à la capacité réelle de l'upstream (ex. ~150) pour qu'un flood de quelques centaines de req/s atteigne `high`.
 - **Hors première tranche** (suivi) : traitement actif des clients non-navigateurs sans clearance sous attaque (cap `THROTTLE`/`TARPIT` au lieu d'un simple laissez-passer) ; sous-mode « siège » strict ; alerte de sortie sur éviction LRU d'un scope encore actif (cas rare, métrique réinitialisée à la requête suivante).
 - **Conformité ADR-016** : le mode ne produit aucun blocage dur à lui seul — la seule action forcée est un `CHALLENGE` réversible.
+
+### FR-06 — `domains[].challenge_enabled` : périmètre du correctif
+
+- **Corrigé** : la clé était documentée et désérialisée mais **jamais lue** — le challenge JS suivait uniquement `challenge.enabled`. Elle devient une surcharge à trois états (`nil` hérite du global, `false` désactive y compris sous FR-39, `true` force malgré un global éteint), résolue par hôte avec les règles de routage `domains[]` (casse, port, wildcard couvrant l'apex, première correspondance).
+- **Pourquoi `*bool`** : avec un `bool` nu, le zéro-valeur aurait désactivé le challenge sur toute entrée `domains[]` déclarée pour son seul `upstream` ou son certificat TLS — un fail-open silencieux sur une protection de sécurité.
+- **Hors périmètre, délibérément** : `protected_paths`, `public_paths`, `rate_limit_override` et `trust_override` restent **non câblés** (documenté comme tel dans CONFIG.md). Ils sont acceptés par le schéma et sans effet ; leur implémentation demande ses propres specs et gates.
 
 ## Security Scan Triage (Semgrep OSS)
 


### PR DESCRIPTION
## Résumé

- **`domains[].challenge_enabled` n'avait aucun effet.** La clé était documentée (`CONFIG.md`, `config.schema.json`) et désérialisée dans `config.DomainConfig`, mais **jamais lue** : le challenge JS était monté et servi uniquement selon le `challenge.enabled` global. Un domaine déclarant `challenge_enabled: false` recevait quand même la page de challenge ; un domaine déclarant `true` restait sans challenge si le global était éteint.
- **Le champ devient un `*bool` à trois états** — absent = hérite du global, `false` = jamais de challenge sur ce domaine (y compris sous le mode « sous attaque » FR-39), `true` = force le challenge même avec `challenge.enabled: false`. Le pointeur est indispensable : avec un `bool` nu, le zéro-valeur aurait désactivé le challenge sur toute entrée `domains[]` déclarée pour son seul `upstream` ou son certificat TLS — un **fail-open silencieux** sur une protection de sécurité.
- **Résolution par hôte alignée sur le routage `domains[]`** (casse ignorée, port retiré, wildcard `*.example.com` couvrant l'apex, première correspondance gagnante), et montage de la chaîne via `challenge.Enabled(cfg)` pour qu'un domaine puisse activer le challenge alors que le global est éteint.

## Références

- Spec : `specs/requirements.md` FR-06 (2.1.0 → **2.2.0**), `specs/features/js-challenge.feature` (6 scénarios), `specs/schemas/config.schema.json`
- Suivi : `specs/tasks.md` T13.1 · Gates : `specs/validation.md`
- Commits : `spec(...) [spec only]` puis `fix(...)`, conformément au flux SDD du repo

## Deux décisions à valider en review

**1. Préséance sur le mode « sous attaque » (FR-39).** `challenge_enabled: false` **prime** sur l'escalade automatique. C'est une déclaration explicite de l'opérateur (typiquement une API dont les clients ne peuvent pas exécuter de JS) ; la forcer pendant un incident casserait exactement les clients qu'on veut préserver. Le domaine reste couvert par blacklist, rate-limit, anti-bot et moteur de risque. Comportement spécifié en FR-06 et couvert par un test — à inverser si le choix ne convient pas.

**2. Périmètre volontairement restreint.** Seul `challenge_enabled` est câblé. `protected_paths`, `public_paths`, `rate_limit_override` et `trust_override` ont **le même défaut** (acceptés par le schéma, branchés sur rien) et restent **non implémentés** : chacun demande ses propres specs et gates. Un encart dans `CONFIG.md` les signale désormais comme sans effet, pour ne plus induire le lecteur en erreur.

---

## Checklist SDD — 7 gates

### Spécification
- [x] **G0 — Spec** : FR-06 mis à jour (`approved`, 2.2.0) + 6 scénarios Gherkin + schéma JSON, commités **avant** le code (commit `[spec only]` séparé)
- [x] **G0 — Pas de breaking change silencieux** : `*bool` est un changement de type interne, pas de contrat. Le YAML existant reste valide **à l'identique** : une clé absente conserve le comportement global (elle l'avait déjà, le champ étant mort), `true`/`false` se désérialisent sans changement de syntaxe. Aucun ADR requis. **Voir « Impact prod » ci-dessous** pour le seul changement de comportement observable.

### Qualité technique
- [x] **G1 — Spec lint** : `config.schema.json` valide (parse JSON) ; `.spectral.yaml` ne cible que l'OpenAPI, inchangé ici
- [x] **G2 — Type check** : `go build ./...` + `go vet ./...` sans erreur ; `gofmt -l` vide
- [x] **G3 — Conformance API** : `POST /waf/verify` inchangé (mêmes status codes et corps d'erreur) ; un test vérifie qu'il reste servi par le WAF sur un domaine sans challenge
- [x] **G4 — Tests** : `go test ./...` → **413 tests, 41 paquets**, tous verts (+23 vs `main`). Voir « Plan de test »
- [x] **G5 — Sécurité** : aucun nouveau `nolint`/`nosemgrep`, aucun secret. Le choix du `*bool` **élimine** un fail-open ; le sens du défaut reste « protégé »
- [ ] **G6 — Performance** : une comparaison de préfixe d'hôte par requête sur une liste de domaines (typiquement < 40), sans allocation ni verrou — pas de régression attendue. Aucun benchmark exécuté
- [ ] **G7 — Review humaine**

> `golangci-lint` n'est pas installé sur le poste — **non exécuté localement**, couvert par le job `lint` du CI. Noté comme tel dans `validation.md` plutôt que coché.

## Plan de test

- [x] **Table du gate** (11 cas) : héritage du global (activé/désactivé), `false`/`true` explicites, hôte non listé, casse + port, wildcard sous-domaine **et** apex, première correspondance gagnante, hôte IPv6 littéral
- [x] **Montage** (`challenge.Enabled`) : global activé ; global éteint sans domaine ; global éteint + domaine à `true` → monté ; global activé + tous domaines à `false` → reste monté pour les hôtes non listés
- [x] **Middleware** : domaine désactivé → passe à l'upstream ; domaine **sans la clé** → challengé (non-régression du fail-open) ; `X-WAF-Under-Attack-Enforce` → `false` explicite respecté ; `POST /waf/verify` servi sur un domaine sans challenge
- [x] **Config** : tri-état YAML (absent → `nil`, `false` → false explicite, `true` → true explicite)
- [x] **E2E `routes()`** : chaîne complète, global éteint, `boxaria.fr` à `true` → page de challenge ; `api.boxaria.fr` à `false` → proxy ; hôte non listé → proxy
- [x] **Mutation checks** — les deux gates sont **vérifiés en échec**, pas seulement verts :
  - condition de montage remise à `cfg.Challenge.Enabled` → `boxaria.fr` ne reçoit plus le challenge (204 au lieu de la page)
  - `enabledFor` neutralisé → `TestMiddlewareSkipsChallengeOnDisabledDomain` et `TestMiddlewareDisabledDomainWinsOverUnderAttack` échouent

## Impact prod

Un domaine listé **sans** `challenge_enabled` se comportait déjà comme « global » (le champ était mort) : **aucun changement**.

En revanche, tout domaine qui déclarait `challenge_enabled: false` était **silencieusement challengé** et cessera de l'être au déploiement. C'est le correctif qui opère, mais c'est un changement de comportement observable en production — à anticiper sur `boxaria.fr`, à l'origine du rapport.

```
Go build: Success
Go vet:   No issues found
Go test:  413 passed in 41 packages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
